### PR TITLE
feat(data-pipeline): add concurrent idempotent processing flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,17 @@ NEO4J_PASSWORD=
 
 
 ########################################
+# Data Pipeline Runtime Controls
+########################################
+
+# Max parallel pages processed per batch in src/data_pipeline/pipeline.py
+DATA_PIPELINE_MAX_CONCURRENCY=4
+
+# Minutes after which an in-progress document claim can be reclaimed
+DATA_PIPELINE_CLAIM_STALE_MINUTES=30
+
+
+########################################
 # MCP Server Networking
 ########################################
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,10 @@ LANGFUSE_PUBLIC_KEY=...
 ```
 AZURE_STORAGE_CONNECTION_STRING=...
 AZURE_CONTAINER_NAME=...
+
+# Concurrent pipeline controls
+DATA_PIPELINE_MAX_CONCURRENCY=4
+DATA_PIPELINE_CLAIM_STALE_MINUTES=30
 ```
 
 **Service ports (have defaults):**
@@ -298,6 +302,12 @@ LLM generates Cypher INSERT statements separated by `|` (pipe character). Strict
 - Unique variable names per statement
 - Polish characters normalized (ó→o, ę→e, etc.)
 - Token limit: 65536 to avoid DeepSeek API errors
+
+### Concurrent Pipeline Idempotency
+The data pipeline processes pages in batches with configurable concurrency and hash-based idempotency:
+- `DATA_PIPELINE_MAX_CONCURRENCY` controls max parallel pages per batch.
+- `ProcessedDocument {hash}` nodes prevent duplicate processing for repeated pages.
+- Failed or stale `processing` claims can be retried/reclaimed based on `DATA_PIPELINE_CLAIM_STALE_MINUTES`.
 
 ### Session Management
 `SessionManager` is thread-safe in-memory storage (dict + `threading.Lock`). Not persisted across restarts. Suitable for single-instance deployments only.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,17 @@ NEO4J_PASSWORD=
 
 
 ########################################
+# Data Pipeline Runtime Controls
+########################################
+
+# Max parallel pages processed per batch
+DATA_PIPELINE_MAX_CONCURRENCY=4
+
+# Minutes after which a stuck in-progress hash can be reclaimed
+DATA_PIPELINE_CLAIM_STALE_MINUTES=30
+
+
+########################################
 # MCP Server Networking
 ########################################
 
@@ -181,6 +192,8 @@ just frontend-build    # Build for production
 just lint        # Format & lint
 just test        # Run tests
 just ci          # Full CI pipeline
+uv run --with pytest python -m pytest tests/data_pipeline/test_pipeline_concurrency.py -q
+                # Run pipeline concurrency/idempotency tests only
 
 # Data Pipeline
 just prefect-up  # Start Prefect

--- a/src/data_pipeline/flows/graph_populating.py
+++ b/src/data_pipeline/flows/graph_populating.py
@@ -1,8 +1,20 @@
+import logging
 import os
 import uuid
 
 from langchain_neo4j import Neo4jGraph
 from prefect import get_run_logger, task
+from prefect.exceptions import MissingContextError
+
+module_logger = logging.getLogger(__name__)
+
+
+def _get_logger() -> logging.Logger:
+    """Return Prefect run logger when available, otherwise module logger."""
+    try:
+        return get_run_logger()
+    except MissingContextError:
+        return module_logger
 
 
 def _get_claim_stale_minutes() -> int:
@@ -24,7 +36,7 @@ class GraphPopulator:
         if not uri or not username or not password:
             raise ValueError("NEO4J connection settings are required")
 
-        logger = get_run_logger()
+        logger = _get_logger()
         logger.info(f"Connecting to Neo4j at {uri} as {username}")
         self.graph_db = Neo4jGraph(url=uri, username=username, password=password)
 
@@ -126,7 +138,7 @@ class GraphPopulator:
         )
 
     def execute_cypher(self, query: str):
-        logger = get_run_logger()
+        logger = _get_logger()
         if not query or not query.strip():
             logger.error("Empty Cypher query")
             return
@@ -142,7 +154,7 @@ class GraphPopulator:
 @task
 def claim_document_for_processing(doc_hash: str) -> bool:
     """Claim document hash in Neo4j for idempotent processing."""
-    logger = get_run_logger()
+    logger = _get_logger()
     pop = GraphPopulator()
     claimed = pop.claim_document_hash(doc_hash)
     if claimed:
@@ -155,7 +167,7 @@ def claim_document_for_processing(doc_hash: str) -> bool:
 @task
 def populate_graph(cypher_query: str, doc_hash: str = ""):
     """Execute a cypher query against the configured Neo4j instance."""
-    logger = get_run_logger()
+    logger = _get_logger()
     logger.info("populate_graph task received query of length %d", len(cypher_query or ""))
     pop = GraphPopulator()
     try:

--- a/src/data_pipeline/flows/graph_populating.py
+++ b/src/data_pipeline/flows/graph_populating.py
@@ -1,13 +1,24 @@
 import os
+import uuid
 
 from langchain_neo4j import Neo4jGraph
 from prefect import get_run_logger, task
 
 
+def _get_claim_stale_minutes() -> int:
+    """Read stale claim timeout in minutes from env with safe defaults."""
+    raw_value = os.getenv("DATA_PIPELINE_CLAIM_STALE_MINUTES", "30").strip()
+    try:
+        parsed = int(raw_value)
+    except ValueError:
+        return 30
+    return max(1, parsed)
+
+
 class GraphPopulator:
     def __init__(self):
         uri = os.getenv("NEO4J_URI")
-        username = os.getenv("NEO4J_USERNAME")
+        username = os.getenv("NEO4J_USERNAME") or os.getenv("NEO4J_USER")
         password = os.getenv("NEO4J_PASSWORD")
 
         if not uri or not username or not password:
@@ -16,6 +27,103 @@ class GraphPopulator:
         logger = get_run_logger()
         logger.info(f"Connecting to Neo4j at {uri} as {username}")
         self.graph_db = Neo4jGraph(url=uri, username=username, password=password)
+
+    def claim_document_hash(self, doc_hash: str) -> bool:
+        """Atomically claim a document hash for processing.
+
+        Returns True when processing is allowed for this worker:
+        - first claim for a new hash
+        - retry after a failed run
+        - reclaim stale in-progress work (worker crash/timeout)
+
+        Returns False for hashes already processed or currently claimed.
+        """
+        if not doc_hash:
+            return False
+
+        claim_token = str(uuid.uuid4())
+        stale_minutes = _get_claim_stale_minutes()
+
+        result = self.graph_db.query(
+            """
+            MERGE (doc:ProcessedDocument {hash: $doc_hash})
+            ON CREATE SET
+                doc.created_at = datetime(),
+                doc.updated_at = datetime(),
+                doc.claimed_at = datetime(),
+                doc.status = 'processing',
+                doc.claim_token = $claim_token,
+                doc.attempt_count = 1
+            WITH doc, doc.claim_token = $claim_token AS created_now, datetime() AS now
+            WITH
+                doc,
+                created_now,
+                now,
+                CASE
+                    WHEN created_now THEN true
+                    WHEN doc.status = 'failed' THEN true
+                    WHEN doc.status = 'processing'
+                         AND coalesce(doc.claimed_at, datetime({epochMillis: 0}))
+                             < now - duration({minutes: $stale_minutes})
+                        THEN true
+                    ELSE false
+                END AS can_claim
+            FOREACH (_ IN CASE WHEN can_claim AND NOT created_now THEN [1] ELSE [] END |
+                SET doc.status = 'processing',
+                    doc.claim_token = $claim_token,
+                    doc.claimed_at = now,
+                    doc.updated_at = now,
+                    doc.attempt_count = coalesce(doc.attempt_count, 0) + 1
+            )
+            RETURN can_claim AS claimed
+            """,
+            params={
+                "doc_hash": doc_hash,
+                "claim_token": claim_token,
+                "stale_minutes": stale_minutes,
+            },
+        )
+
+        if not result:
+            return False
+
+        return bool(result[0].get("claimed"))
+
+    def mark_document_processed(self, doc_hash: str) -> None:
+        """Mark a previously claimed document hash as processed."""
+        if not doc_hash:
+            return
+
+        self.graph_db.query(
+            """
+            MATCH (doc:ProcessedDocument {hash: $doc_hash})
+            SET doc.status = 'processed',
+                doc.processed_at = datetime(),
+                doc.updated_at = datetime()
+            REMOVE doc.claim_token
+            """,
+            params={"doc_hash": doc_hash},
+        )
+
+    def mark_document_failed(self, doc_hash: str, error_message: str) -> None:
+        """Mark a claimed document hash as failed with last error details."""
+        if not doc_hash:
+            return
+
+        self.graph_db.query(
+            """
+            MATCH (doc:ProcessedDocument {hash: $doc_hash})
+            SET doc.status = 'failed',
+                doc.failed_at = datetime(),
+                doc.updated_at = datetime(),
+                doc.last_error = $error_message
+            REMOVE doc.claim_token
+            """,
+            params={
+                "doc_hash": doc_hash,
+                "error_message": error_message[:1000],
+            },
+        )
 
     def execute_cypher(self, query: str):
         logger = get_run_logger()
@@ -32,9 +140,27 @@ class GraphPopulator:
 
 
 @task
-def populate_graph(cypher_query: str):
+def claim_document_for_processing(doc_hash: str) -> bool:
+    """Claim document hash in Neo4j for idempotent processing."""
+    logger = get_run_logger()
+    pop = GraphPopulator()
+    claimed = pop.claim_document_hash(doc_hash)
+    if claimed:
+        logger.info("Claimed document hash %s", doc_hash)
+    else:
+        logger.info("Skipping hash %s (already processed or currently in progress)", doc_hash)
+    return claimed
+
+
+@task
+def populate_graph(cypher_query: str, doc_hash: str = ""):
     """Execute a cypher query against the configured Neo4j instance."""
     logger = get_run_logger()
     logger.info("populate_graph task received query of length %d", len(cypher_query or ""))
     pop = GraphPopulator()
-    pop.execute_cypher(cypher_query)
+    try:
+        pop.execute_cypher(cypher_query)
+        pop.mark_document_processed(doc_hash)
+    except Exception as exc:
+        pop.mark_document_failed(doc_hash, str(exc))
+        raise

--- a/src/data_pipeline/pipeline.py
+++ b/src/data_pipeline/pipeline.py
@@ -3,6 +3,7 @@ from hashlib import sha256
 
 from dotenv import load_dotenv
 from prefect import flow, get_run_logger
+from prefect.futures import as_completed
 
 from src.data_pipeline.flows.data_acquisition import acquire_data
 from src.data_pipeline.flows.graph_populating import claim_document_for_processing, populate_graph
@@ -98,7 +99,8 @@ def data_pipeline_flow():
         batch_end = min(batch_start + max_concurrency, len(pages))
         logger.info("Processing batch pages %d-%d", batch_start + 1, batch_end)
 
-        batch_claims = []
+        claim_futures = []
+        claim_lookup = {}
         batch_futures = []
 
         for page_index, page_content in enumerate(
@@ -107,9 +109,11 @@ def data_pipeline_flow():
         ):
             page_hash = _compute_page_hash(page_content)
             claim_future = claim_document_for_processing.submit(page_hash)
-            batch_claims.append((page_index, page_content, page_hash, claim_future))
+            claim_futures.append(claim_future)
+            claim_lookup[id(claim_future)] = (page_index, page_content, page_hash)
 
-        for page_index, page_content, page_hash, claim_future in batch_claims:
+        for claim_future in as_completed(claim_futures):
+            page_index, page_content, page_hash = claim_lookup[id(claim_future)]
             try:
                 is_claimed = claim_future.result()
             except Exception as exc:

--- a/src/data_pipeline/pipeline.py
+++ b/src/data_pipeline/pipeline.py
@@ -1,27 +1,61 @@
+import os
+from hashlib import sha256
+
 from dotenv import load_dotenv
 from prefect import flow, get_run_logger
 
 from src.data_pipeline.flows.data_acquisition import acquire_data
-from src.data_pipeline.flows.graph_populating import populate_graph
+from src.data_pipeline.flows.graph_populating import claim_document_for_processing, populate_graph
 from src.data_pipeline.flows.llm_cypher_generation import generate_cypher_queries
 from src.data_pipeline.flows.schema_reflection import reflect_on_schema
 
 
+def _get_max_concurrency() -> int:
+    """Read max concurrency from env with a safe fallback."""
+    raw_value = os.getenv("DATA_PIPELINE_MAX_CONCURRENCY", "4").strip()
+    try:
+        parsed_value = int(raw_value)
+    except ValueError:
+        return 4
+    return max(1, parsed_value)
+
+
+def _compute_page_hash(page_content: str) -> str:
+    """Create a stable idempotency hash for one page of content."""
+    normalized_content = page_content.strip().encode("utf-8")
+    return sha256(normalized_content).hexdigest()
+
+
+def _safe_reflect_schema(phase: str, logger) -> str:
+    """Reflect schema once and degrade safely on transient errors."""
+    try:
+        schema_summary = reflect_on_schema()
+    except Exception as exc:
+        logger.warning("Schema reflection failed during %s: %s", phase, exc)
+        return ""
+
+    if not schema_summary:
+        logger.info("Schema reflection during %s returned empty summary", phase)
+        return ""
+
+    logger.info(
+        "Schema reflection during %s produced %d chars",
+        phase,
+        len(schema_summary),
+    )
+    return schema_summary
+
+
 @flow(log_prints=True)
 def data_pipeline_flow():
-    """Agentic graph extraction loop.
+    """Agentic graph extraction loop with batched parallel processing.
 
-    For each page of source content:
-      1. Extract text via OCR/text loader.
-      2. Generate Cypher MERGE statements with the LLM, injecting the current
-         graph schema as context so the model stays consistent with what is
-         already stored.
-      3. Populate the Neo4j graph with the generated statements.
-      4. Reflect on the updated schema to produce a concise summary for the
-         next iteration.
+    Each page is processed through the same generate -> populate chain.
+    Pages are submitted in batches so concurrency is bounded by
+    DATA_PIPELINE_MAX_CONCURRENCY.
 
-    The loop runs until all pages are processed, then the graph is ready for
-    querying by the RAG pipeline.
+    Once all batches finish, schema reflection runs once to summarize the final
+    graph state for observability.
     """
     load_dotenv()
     logger = get_run_logger()
@@ -32,24 +66,116 @@ def data_pipeline_flow():
     if isinstance(pages, str):
         pages = [pages]
 
-    schema_context: str = ""
+    pages = [page for page in pages if page and page.strip()]
+    if not pages:
+        logger.warning("No non-empty pages found; stopping pipeline early")
+        return
 
-    for i, page_content in enumerate(pages):
-        logger.info("Processing page %d / %d", i + 1, len(pages))
+    stats = {
+        "total_pages": len(pages),
+        "claimed_pages": 0,
+        "submitted_pages": 0,
+        "skipped_duplicates": 0,
+        "successful_pages": 0,
+        "failed_pages": 0,
+        "claim_errors": 0,
+        "schema_snapshot_chars": 0,
+        "schema_final_chars": 0,
+    }
 
-        if not page_content or not page_content.strip():
-            logger.warning("Page %d is empty — skipping", i + 1)
-            continue
+    max_concurrency = _get_max_concurrency()
+    logger.info(
+        "Submitting %d pages with max concurrency %d",
+        len(pages),
+        max_concurrency,
+    )
 
-        cypher_query = generate_cypher_queries(page_content, schema_context)
+    # Race-safe schema strategy: capture once before fan-out and reuse for all pages.
+    schema_context = _safe_reflect_schema(phase="before_parallel_batches", logger=logger)
+    stats["schema_snapshot_chars"] = len(schema_context)
 
-        if cypher_query:
-            populate_graph(cypher_query)
-        else:
-            logger.warning("No Cypher generated for page %d — skipping populate", i + 1)
+    for batch_start in range(0, len(pages), max_concurrency):
+        batch_end = min(batch_start + max_concurrency, len(pages))
+        logger.info("Processing batch pages %d-%d", batch_start + 1, batch_end)
 
-        # Reflect on the graph after each page to update schema context
-        schema_context = reflect_on_schema()
+        batch_claims = []
+        batch_futures = []
+
+        for page_index, page_content in enumerate(
+            pages[batch_start:batch_end],
+            start=batch_start + 1,
+        ):
+            page_hash = _compute_page_hash(page_content)
+            claim_future = claim_document_for_processing.submit(page_hash)
+            batch_claims.append((page_index, page_content, page_hash, claim_future))
+
+        for page_index, page_content, page_hash, claim_future in batch_claims:
+            try:
+                is_claimed = claim_future.result()
+            except Exception as exc:
+                stats["failed_pages"] += 1
+                stats["claim_errors"] += 1
+                logger.error(
+                    "Claim failed for page %d / %d (hash=%s): %s",
+                    page_index,
+                    len(pages),
+                    page_hash,
+                    exc,
+                )
+                continue
+
+            if not is_claimed:
+                stats["skipped_duplicates"] += 1
+                logger.info(
+                    "Skipping page %d / %d (already processed hash=%s)",
+                    page_index,
+                    len(pages),
+                    page_hash,
+                )
+                continue
+
+            stats["claimed_pages"] += 1
+            logger.info("Submitting page %d / %d", page_index, len(pages))
+            cypher_future = generate_cypher_queries.submit(page_content, schema_context)
+            populate_future = populate_graph.submit(cypher_future, page_hash)
+            stats["submitted_pages"] += 1
+            batch_futures.append((page_index, page_hash, populate_future))
+
+        for page_index, page_hash, future in batch_futures:
+            try:
+                future.result()
+                stats["successful_pages"] += 1
+            except Exception as exc:
+                stats["failed_pages"] += 1
+                logger.error(
+                    "Processing failed for page %d / %d (hash=%s): %s",
+                    page_index,
+                    len(pages),
+                    page_hash,
+                    exc,
+                )
+
+    # Run one final reflection only after all futures have settled.
+    final_schema = _safe_reflect_schema(phase="after_parallel_batches", logger=logger)
+    stats["schema_final_chars"] = len(final_schema)
+    logger.info("Pipeline complete. Final schema summary length: %d", stats["schema_final_chars"])
+    logger.info(
+        "Pipeline summary: total=%d claimed=%d submitted=%d success=%d "
+        "skipped_duplicates=%d failed=%d claim_errors=%d "
+        "schema_snapshot_chars=%d schema_final_chars=%d",
+        stats["total_pages"],
+        stats["claimed_pages"],
+        stats["submitted_pages"],
+        stats["successful_pages"],
+        stats["skipped_duplicates"],
+        stats["failed_pages"],
+        stats["claim_errors"],
+        stats["schema_snapshot_chars"],
+        stats["schema_final_chars"],
+    )
+
+    if stats["failed_pages"] > 0:
+        logger.warning("Pipeline finished with %d failed pages", stats["failed_pages"])
 
     logger.info("Pipeline complete. Graph is ready for querying.")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/data_pipeline/test_pipeline_concurrency.py
+++ b/tests/data_pipeline/test_pipeline_concurrency.py
@@ -1,5 +1,7 @@
 from collections.abc import Callable
 
+import pytest
+
 from src.data_pipeline import pipeline as pipeline_module
 
 
@@ -31,6 +33,11 @@ class SubmitStub:
     def submit(self, *args, **kwargs):
         self.calls.append((args, kwargs))
         return self.submit_impl(*args, **kwargs)
+
+
+@pytest.fixture(autouse=True)
+def patch_as_completed(monkeypatch):
+    monkeypatch.setattr(pipeline_module, "as_completed", lambda futures: futures)
 
 
 def test_pipeline_uses_batched_parallel_processing(monkeypatch):

--- a/tests/data_pipeline/test_pipeline_concurrency.py
+++ b/tests/data_pipeline/test_pipeline_concurrency.py
@@ -1,0 +1,167 @@
+from collections.abc import Callable
+
+from src.data_pipeline import pipeline as pipeline_module
+
+
+class ImmediateFuture:
+    def __init__(
+        self,
+        value=None,
+        *,
+        error: Exception | None = None,
+        on_result: Callable[[], None] | None = None,
+    ):
+        self._value = value
+        self._error = error
+        self._on_result = on_result
+
+    def result(self):
+        if self._on_result:
+            self._on_result()
+        if self._error is not None:
+            raise self._error
+        return self._value
+
+
+class SubmitStub:
+    def __init__(self, submit_impl: Callable[..., ImmediateFuture]):
+        self.submit_impl = submit_impl
+        self.calls: list[tuple[tuple, dict]] = []
+
+    def submit(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return self.submit_impl(*args, **kwargs)
+
+
+def test_pipeline_uses_batched_parallel_processing(monkeypatch):
+    pages = [f"page-{i}" for i in range(10)]
+    reflection_calls: list[int] = []
+    active_populates = 0
+    max_active_populates = 0
+
+    monkeypatch.setenv("DATA_PIPELINE_MAX_CONCURRENCY", "3")
+    monkeypatch.setattr(pipeline_module, "acquire_data", lambda: pages)
+
+    def fake_reflect():
+        reflection_calls.append(1)
+        return "schema-summary"
+
+    monkeypatch.setattr(pipeline_module, "reflect_on_schema", fake_reflect)
+
+    claim_stub = SubmitStub(lambda _doc_hash: ImmediateFuture(True))
+    monkeypatch.setattr(pipeline_module, "claim_document_for_processing", claim_stub)
+
+    generate_stub = SubmitStub(
+        lambda _page_content, _schema_context: ImmediateFuture("MERGE (n:Entity {title: 'x'})")
+    )
+    monkeypatch.setattr(pipeline_module, "generate_cypher_queries", generate_stub)
+
+    def populate_submit(_cypher_future, _doc_hash):
+        nonlocal active_populates
+        nonlocal max_active_populates
+
+        active_populates += 1
+        max_active_populates = max(max_active_populates, active_populates)
+
+        def release_slot():
+            nonlocal active_populates
+            active_populates -= 1
+
+        return ImmediateFuture(None, on_result=release_slot)
+
+    populate_stub = SubmitStub(populate_submit)
+    monkeypatch.setattr(pipeline_module, "populate_graph", populate_stub)
+
+    pipeline_module.data_pipeline_flow()
+
+    assert len(claim_stub.calls) == 10
+    assert len(generate_stub.calls) == 10
+    assert len(populate_stub.calls) == 10
+    assert max_active_populates <= 3
+    assert max_active_populates == 3
+    assert len(reflection_calls) == 2
+
+
+def test_pipeline_skips_duplicate_hashes(monkeypatch):
+    pages = ["same", "same", "unique"]
+
+    monkeypatch.setenv("DATA_PIPELINE_MAX_CONCURRENCY", "4")
+    monkeypatch.setattr(pipeline_module, "acquire_data", lambda: pages)
+    monkeypatch.setattr(pipeline_module, "reflect_on_schema", lambda: "schema-summary")
+
+    claim_results = iter([True, False, True])
+    claim_stub = SubmitStub(lambda _doc_hash: ImmediateFuture(next(claim_results)))
+    monkeypatch.setattr(pipeline_module, "claim_document_for_processing", claim_stub)
+
+    generate_stub = SubmitStub(
+        lambda _page_content, _schema_context: ImmediateFuture("MERGE (n:Entity {title: 'x'})")
+    )
+    monkeypatch.setattr(pipeline_module, "generate_cypher_queries", generate_stub)
+
+    populate_stub = SubmitStub(lambda _cypher_future, _doc_hash: ImmediateFuture(None))
+    monkeypatch.setattr(pipeline_module, "populate_graph", populate_stub)
+
+    pipeline_module.data_pipeline_flow()
+
+    assert len(claim_stub.calls) == 3
+    assert len(generate_stub.calls) == 2
+    assert len(populate_stub.calls) == 2
+
+    first_hash = claim_stub.calls[0][0][0]
+    second_hash = claim_stub.calls[1][0][0]
+    third_hash = claim_stub.calls[2][0][0]
+    assert first_hash == second_hash
+    assert first_hash != third_hash
+
+
+def test_pipeline_continues_after_page_failure(monkeypatch):
+    pages = ["p0", "p1", "p2"]
+    reflection_calls: list[int] = []
+
+    monkeypatch.setenv("DATA_PIPELINE_MAX_CONCURRENCY", "3")
+    monkeypatch.setattr(pipeline_module, "acquire_data", lambda: pages)
+
+    def fake_reflect():
+        reflection_calls.append(1)
+        return "schema-summary"
+
+    monkeypatch.setattr(pipeline_module, "reflect_on_schema", fake_reflect)
+    monkeypatch.setattr(
+        pipeline_module,
+        "claim_document_for_processing",
+        SubmitStub(lambda _doc_hash: ImmediateFuture(True)),
+    )
+    monkeypatch.setattr(
+        pipeline_module,
+        "generate_cypher_queries",
+        SubmitStub(
+            lambda _page_content, _schema_context: ImmediateFuture("MERGE (n:Entity {x: 1})")
+        ),
+    )
+
+    failure_index = {"value": 0}
+
+    def populate_submit(_cypher_future, _doc_hash):
+        idx = failure_index["value"]
+        failure_index["value"] += 1
+        if idx == 1:
+            return ImmediateFuture(error=RuntimeError("boom"))
+        return ImmediateFuture(None)
+
+    populate_stub = SubmitStub(populate_submit)
+    monkeypatch.setattr(pipeline_module, "populate_graph", populate_stub)
+
+    pipeline_module.data_pipeline_flow()
+
+    assert len(populate_stub.calls) == 3
+    assert len(reflection_calls) == 2
+
+
+def test_hash_function_is_stable():
+    left = pipeline_module._compute_page_hash("some content")
+    right = pipeline_module._compute_page_hash("some content")
+    different = pipeline_module._compute_page_hash("other content")
+
+    assert left == right
+    assert left != different
+    assert len(left) == 64


### PR DESCRIPTION
#19 
- Replace sequential page loop with bounded parallel batches in Prefect flow

- Add hash-based claim/processed/failed tracking in Neo4j with stale claim reclaim

- Add race-safe schema reflection strategy (before/after batches) and run summary counters

- Add integration-style tests for 10-page processing, duplicate skip, and failure isolation

- Document DATA_PIPELINE_MAX_CONCURRENCY and DATA_PIPELINE_CLAIM_STALE_MINUTES