### PR TITLE
fix: address PR review for LLM hardening and API Docker import

### DIFF
--- a/graph_config.yaml
+++ b/graph_config.yaml
@@ -32,6 +32,8 @@ llm:
   clarin:
     name: "pllum"
     base_url: "https://services.clarin-pl.eu/api/v1/oapi"
+  deepseek:
+    base_url: "https://api.deepseek.com"
   gemini:
     name: "gemini-2.5-flash-lite"
 

--- a/graph_config.yaml
+++ b/graph_config.yaml
@@ -144,8 +144,11 @@ prompts:
     You are a classifier for a Wrocław University of Science and Technology (Politechnika Wrocławska) assistant.
     Assume that any question mentioning professors, teachers, courses, classes, departments, buildings,
     research, or other academic topics refers to Politechnika Wrocławska.
-    Is this question related to university topics (answer "generate_cypher") or completely unrelated (answer "end")?
-    Answer ONLY: "generate_cypher" or "end"
+    Decide whether to continue graph retrieval ("generate") or stop ("end").
+    Answer ONLY with valid JSON in this exact shape:
+    {"decision": "generate"}
+    or
+    {"decision": "end"}
 
     Question: {user_question}
     Answer:

--- a/graph_config.yaml
+++ b/graph_config.yaml
@@ -25,6 +25,10 @@ llm:
   accurate_model:
     name: "gpt-5.4-mini"
     temperature: 0
+  provider_fallback_order:
+    - "openai"
+    # - "deepseek"    # Uncomment when DEEPSEEK_API_KEY is set
+    # - "google"      # Uncomment when GOOGLE_API_KEY is set
   clarin:
     name: "pllum"
     base_url: "https://services.clarin-pl.eu/api/v1/oapi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pydantic>=2.10.0",
     "pyyaml>=6.0.0",
     "ruff>=0.14.1",
+    "tenacity>=9.1.2",
     "uvicorn>=0.34.0",
 ]
 

--- a/src/config/config_models.py
+++ b/src/config/config_models.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-
 from pydantic import BaseModel
 
 
@@ -46,6 +45,10 @@ class Clarin(BaseModel):
     base_url: str
 
 
+class Deepseek(BaseModel):
+    base_url: str
+
+
 class Gemini(BaseModel):
     name: str
 
@@ -53,7 +56,9 @@ class Gemini(BaseModel):
 class Llm(BaseModel):
     fast_model: FastModel
     accurate_model: AccurateModel
+    provider_fallback_order: list[str]
     clarin: Clarin
+    deepseek: Deepseek
     gemini: Gemini
 
 

--- a/src/config/messages.py
+++ b/src/config/messages.py
@@ -1,0 +1,8 @@
+"""Shared user-facing error messages for LLM and pipeline timeouts."""
+
+GRAPH_PIPELINE_TIMEOUT_MESSAGE = (
+    "The knowledge graph pipeline exceeded the maximum allowed wait time."
+)
+LLM_CALL_TIMEOUT_MESSAGE = (
+    "The language model request exceeded the maximum allowed wait time."
+)

--- a/src/data_pipeline/flows/llm_cypher_generation.py
+++ b/src/data_pipeline/flows/llm_cypher_generation.py
@@ -25,6 +25,7 @@ class LLMPipe:
             model=config.llm.accurate_model.name,
             api_key=SecretStr(os.getenv("OPENAI_API_KEY") or ""),
             temperature=config.llm.accurate_model.temperature,
+            timeout=30.0,
         )
         self.generate_template = PromptTemplate(
             input_variables=["context", "schema_context"],

--- a/src/data_pipeline/flows/schema_reflection.py
+++ b/src/data_pipeline/flows/schema_reflection.py
@@ -42,6 +42,7 @@ def reflect_on_schema() -> str:
         model=config.llm.fast_model.name,
         api_key=SecretStr(api_key),
         temperature=config.llm.fast_model.temperature,
+        timeout=30.0,
     )
 
     template = PromptTemplate(

--- a/src/mcp_client/client.py
+++ b/src/mcp_client/client.py
@@ -11,7 +11,7 @@ from langchain_openai.chat_models.base import BaseChatOpenAI
 from pydantic import SecretStr
 
 from ..config.config import get_config
-from ..mcp_server.tools.knowledge_graph.rag import RAG
+from ..config.messages import LLM_CALL_TIMEOUT_MESSAGE
 
 load_dotenv()
 
@@ -144,7 +144,7 @@ async def query_knowledge_graph(
             timeout=llm_timeout_sec,
         )
     except asyncio.TimeoutError as exc:
-        raise TimeoutError(RAG.LLM_CALL_TIMEOUT_MESSAGE) from exc
+        raise TimeoutError(LLM_CALL_TIMEOUT_MESSAGE) from exc
 
     print(llm_response.content)
     return llm_response

--- a/src/mcp_client/client.py
+++ b/src/mcp_client/client.py
@@ -11,6 +11,7 @@ from langchain_openai.chat_models.base import BaseChatOpenAI
 from pydantic import SecretStr
 
 from ..config.config import get_config
+from ..mcp_server.tools.knowledge_graph.rag import RAG
 
 load_dotenv()
 
@@ -31,18 +32,21 @@ if openai_api_key:
         model=config.llm.accurate_model.name,
         api_key=SecretStr(openai_api_key),
         temperature=config.llm.accurate_model.temperature,
+        timeout=30.0,
     )
 elif clarin_api_key:
     llm = ChatOpenAI(
         model_name=config.llm.clarin.name,
         base_url=config.llm.clarin.base_url,
         api_key=clarin_api_key,
+        timeout=30.0,
     )
 elif google_api_key:
     llm = ChatGoogleGenerativeAI(
         model=config.llm.gemini.name,
         google_api_key=google_api_key,
         temperature=1.0,
+        timeout=30.0,
     )
 else:
     raise ValueError(
@@ -106,7 +110,11 @@ async def get_knowledge_graph_data(
         return result.content
 
 
-async def query_knowledge_graph(user_input: str, trace_id: str = None):
+async def query_knowledge_graph(
+    user_input: str,
+    trace_id: str = None,
+    llm_timeout_sec: float = 30.0,
+):
     """Query the knowledge graph with user input."""
 
     trace_id = str(uuid.uuid4().hex)
@@ -130,7 +138,13 @@ async def query_knowledge_graph(user_input: str, trace_id: str = None):
     if handler is not None:
         invoke_config["callbacks"] = [handler]
 
-    llm_response = await llm.ainvoke(final_prompt, config=invoke_config)
+    try:
+        llm_response = await asyncio.wait_for(
+            llm.ainvoke(final_prompt, config=invoke_config),
+            timeout=llm_timeout_sec,
+        )
+    except asyncio.TimeoutError as exc:
+        raise TimeoutError(RAG.LLM_CALL_TIMEOUT_MESSAGE) from exc
 
     print(llm_response.content)
     return llm_response

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -36,7 +36,10 @@ else:
     print("Langfuse credentials not configured. Tracing disabled.")
 
 
-def initialize_rag():
+def initialize_rag(
+    llm_timeout_sec: float = 30.0,
+    graph_timeout_sec: float = 90.0,
+):
     """Initialize RAG instance with environment variables."""
     global rag
 
@@ -57,6 +60,8 @@ def initialize_rag():
         neo4j_url=neo4j_uri,
         neo4j_username=neo4j_username,
         neo4j_password=neo4j_password,
+        llm_timeout_sec=llm_timeout_sec,
+        graph_timeout_sec=graph_timeout_sec,
     )
 
     return rag

--- a/src/mcp_server/tools/knowledge_graph/rag.py
+++ b/src/mcp_server/tools/knowledge_graph/rag.py
@@ -1,5 +1,7 @@
+import asyncio
 import json
 import os
+import re
 from typing import Any, Dict
 
 from langchain_core.output_parsers import StrOutputParser
@@ -9,14 +11,22 @@ from langchain_neo4j import Neo4jGraph
 from langchain_openai.chat_models.base import BaseChatOpenAI
 from langfuse.langchain import CallbackHandler
 from langgraph.graph import END, START, StateGraph
+from tenacity import retry, stop_after_attempt, wait_exponential, wait_random
 
 from ....config.config import get_config
 from .graph_visualizer import GraphVisualizer
 from .state import State
 
+FORBIDDEN_CLAUSES = frozenset({"CREATE", "MERGE", "DELETE", "DETACH", "SET", "REMOVE", "DROP"})
+
 
 class RAG:
     """Retrieval-Augmented Generation system with Neo4j graph database backend."""
+
+    GRAPH_PIPELINE_TIMEOUT_MESSAGE = (
+        "The knowledge graph pipeline exceeded the maximum allowed wait time."
+    )
+    LLM_CALL_TIMEOUT_MESSAGE = "The language model request exceeded the maximum allowed wait time."
 
     def __init__(
         self,
@@ -26,6 +36,8 @@ class RAG:
         neo4j_password: str,
         enable_debug: bool = None,
         max_results: int = None,
+        llm_timeout_sec: float = 30.0,
+        graph_timeout_sec: float = 90.0,
     ):
         """
         Initialize RAG system with API keys and database credentials.
@@ -37,9 +49,12 @@ class RAG:
             neo4j_password: Neo4j password
             enable_debug: Enable debug output (default: False)
             max_results: Maximum number of results from Neo4j (default: 5)
+            llm_timeout_sec: Per-call HTTP timeout for each LLM client
+            graph_timeout_sec: Max wall time for the full async graph in ainvoke()
         """
         config = get_config()
 
+        self.graph_timeout_sec = graph_timeout_sec
         self.api_key = api_key
         self.enable_debug = enable_debug if enable_debug is not None else config.rag.enable_debug
         self.max_results = max_results if max_results is not None else config.rag.max_results
@@ -53,23 +68,27 @@ class RAG:
                 model=config.llm.fast_model.name,
                 api_key=api_key,
                 temperature=config.llm.fast_model.temperature,
+                timeout=llm_timeout_sec,
             )
 
             self.cypher_llm = BaseChatOpenAI(
                 model=config.llm.accurate_model.name,
                 api_key=api_key,
                 temperature=config.llm.accurate_model.temperature,
+                timeout=llm_timeout_sec,
             )
         else:
             self.fast_llm = ChatGoogleGenerativeAI(
                 model=config.llm.gemini.name,
                 google_api_key=api_key,
                 temperature=1.0,
+                timeout=llm_timeout_sec,
             )
             self.cypher_llm = ChatGoogleGenerativeAI(
                 model=config.llm.gemini.name,
                 google_api_key=api_key,
                 temperature=1.0,
+                timeout=llm_timeout_sec,
             )
 
         self._initialize_prompt_templates()
@@ -87,9 +106,13 @@ class RAG:
         self.visualizer = GraphVisualizer()
         self.graph = self._build_processing_graph()
 
-        self.handler = None
-
-    def _get_invoke_config(self, trace_id: str, tags: list, run_name: str) -> dict:
+    def _get_invoke_config(
+        self,
+        trace_id: str,
+        tags: list,
+        run_name: str,
+        handler: CallbackHandler = None,
+    ) -> dict:
         """Build invoke config with optional callbacks."""
         config = {
             "metadata": {
@@ -98,9 +121,33 @@ class RAG:
                 "run_name": run_name,
             },
         }
-        if self.handler is not None:
-            config["callbacks"] = [self.handler]
+        if handler is not None:
+            config["callbacks"] = [handler]
         return config
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=10) + wait_random(0, 1),
+    )
+    def _invoke_with_retry(self, chain: Any, inputs: Dict[str, Any], config: dict) -> Any:
+        # TODO: fallback chain OpenAI → DeepSeek → Google
+        # Currently only the OpenAI-compatible client path is wired at startup.
+        try:
+            return chain.invoke(inputs, config=config)
+        except TimeoutError as exc:
+            raise TimeoutError(RAG.LLM_CALL_TIMEOUT_MESSAGE) from exc
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=10) + wait_random(0, 1),
+    )
+    async def _ainvoke_with_retry(self, chain: Any, inputs: Dict[str, Any], config: dict) -> Any:
+        # TODO: fallback chain OpenAI → DeepSeek → Google
+        # Currently only the OpenAI-compatible client path is wired at startup.
+        try:
+            return await chain.ainvoke(inputs, config=config)
+        except TimeoutError as exc:
+            raise TimeoutError(RAG.LLM_CALL_TIMEOUT_MESSAGE) from exc
 
     @property
     def schema(self):
@@ -151,6 +198,17 @@ class RAG:
             input_variables=["user_question"], template=config.prompts.guardrails
         )
 
+    def _validate_cypher_readonly(self, query: str) -> None:
+        """Raise if generated Cypher contains write-operation keywords."""
+        clean = re.sub(r"//[^\n]*", "", query)
+        clean = re.sub(r"/\*.*?\*/", "", clean, flags=re.DOTALL)
+
+        tokens = set(re.findall(r"\b[A-Z]+\b", clean.upper()))
+        blocked = tokens & FORBIDDEN_CLAUSES
+
+        if blocked:
+            raise ValueError(f"Cypher zawiera niedozwolone operacje: {blocked}")
+
     def _build_processing_graph(self):
         """Construct the state machine graph for the RAG pipeline."""
         builder = StateGraph(State)
@@ -194,7 +252,7 @@ class RAG:
 
         return builder.compile()
 
-    def generate_cypher(self, state: State):
+    async def generate_cypher(self, state: State):
         """
         Generate CYPHER query from user question using database schema.
         Uses better model (gpt-5-mini) for complex Cypher generation.
@@ -209,7 +267,8 @@ class RAG:
         print(f"[Schema used for Cypher generation] ({len(schema)} chars):\n{schema or '(empty)'}")
 
         chain = self.generate_cypher_template | self.cypher_llm | StrOutputParser()
-        generated_cypher = chain.invoke(
+        generated_cypher = await self._ainvoke_with_retry(
+            chain,
             {
                 "user_question": state["user_question"],
                 "schema": schema,
@@ -218,6 +277,7 @@ class RAG:
                 trace_id=state["trace_id"],
                 tags=["knowledge_graph", "generated_cypher"],
                 run_name="Generate Cypher",
+                handler=state.get("callback_handler"),
             ),
         )
 
@@ -237,6 +297,8 @@ class RAG:
         cypher_query = state.get("generated_cypher", "")
 
         try:
+            self._validate_cypher_readonly(cypher_query)
+
             if "LIMIT" not in cypher_query.upper():
                 cypher_query = f"{cypher_query.rstrip(';')} LIMIT {self.max_results}"
 
@@ -252,7 +314,7 @@ class RAG:
 
             return {"context": [], "generated_cypher": f"Query failed: {error_msg}"}
 
-    def guardrails_system(self, state: State):
+    async def guardrails_system(self, state: State):
         """
         Decide whether to use graph retrieval or general LLM knowledge.
         Uses fast model (gpt-5-nano) for quick decision.
@@ -266,12 +328,14 @@ class RAG:
         guardrails_chain = self.guard_rails_template | self.fast_llm | StrOutputParser()
 
         guardrail_output = (
-            guardrails_chain.invoke(
+            await self._ainvoke_with_retry(
+                guardrails_chain,
                 {"user_question": state["user_question"]},
                 config=self._get_invoke_config(
                     trace_id=state["trace_id"],
                     tags=["knowledge_graph", "guardrails"],
                     run_name="Guardrails",
+                    handler=state.get("callback_handler"),
                 ),
             )
             .strip()
@@ -313,29 +377,7 @@ class RAG:
         Returns:
             Dictionary with context from graph or "W bazie danych nie ma informacji"
         """
-        result = self.graph.invoke({"user_question": message})
-
-        if result.get("answer") == "W bazie danych nie ma informacji":
-            return {
-                "answer": "W bazie danych nie ma informacji",
-                "metadata": {
-                    "guardrail_decision": result.get("guardrail_decision"),
-                    "cypher_query": None,
-                    "context": [],
-                },
-            }
-
-        context_data = result.get("context", [])
-        context_json = json.dumps(context_data, ensure_ascii=False, indent=2)
-
-        return {
-            "answer": context_json,
-            "metadata": {
-                "guardrail_decision": result.get("guardrail_decision"),
-                "cypher_query": result.get("generated_cypher"),
-                "context": context_data,
-            },
-        }
+        return asyncio.run(self.ainvoke(message, session_id=session_id))
 
     async def ainvoke(
         self,
@@ -354,9 +396,20 @@ class RAG:
         Returns:
             Dictionary with context from graph or "W bazie danych nie ma informacji"
         """
-        self.handler = callback_handler
 
-        result = await self.graph.ainvoke({"user_question": message, "trace_id": trace_id})
+        try:
+            result = await asyncio.wait_for(
+                self.graph.ainvoke(
+                    {
+                        "user_question": message,
+                        "trace_id": trace_id,
+                        "callback_handler": callback_handler,
+                    }
+                ),
+                timeout=self.graph_timeout_sec,
+            )
+        except asyncio.TimeoutError as exc:
+            raise TimeoutError(RAG.GRAPH_PIPELINE_TIMEOUT_MESSAGE) from exc
 
         if result.get("answer") == "W bazie danych nie ma informacji":
             return {

--- a/src/mcp_server/tools/knowledge_graph/rag.py
+++ b/src/mcp_server/tools/knowledge_graph/rag.py
@@ -18,6 +18,11 @@ from .graph_visualizer import GraphVisualizer
 from .state import State
 
 FORBIDDEN_CLAUSES = frozenset({"CREATE", "MERGE", "DELETE", "DETACH", "SET", "REMOVE", "DROP"})
+GUARDRAIL_DECISION_ALIASES = {
+    "generate": "generate_cypher",
+    "generate_cypher": "generate_cypher",
+    "end": "end",
+}
 
 
 class RAG:
@@ -209,6 +214,37 @@ class RAG:
         if blocked:
             raise ValueError(f"Cypher zawiera niedozwolone operacje: {blocked}")
 
+    @staticmethod
+    def _strip_code_fences(text: str) -> str:
+        """Remove markdown code fences that may wrap JSON output."""
+        stripped = text.strip()
+        stripped = re.sub(r"^```(?:json)?\s*", "", stripped, flags=re.IGNORECASE)
+        stripped = re.sub(r"\s*```$", "", stripped)
+        return stripped.strip()
+
+    def _parse_guardrail_output(self, raw_output: str) -> Dict[str, str]:
+        """Parse guardrail JSON and normalize the decision with a safe fallback."""
+        cleaned_output = self._strip_code_fences(raw_output)
+        json_match = re.search(r"\{.*\}", cleaned_output, flags=re.DOTALL)
+        payload_text = json_match.group(0) if json_match else cleaned_output
+
+        try:
+            payload = json.loads(payload_text)
+        except json.JSONDecodeError as exc:
+            if self.enable_debug:
+                print(f"[Guardrails Parse Error] invalid JSON: {exc}; raw={raw_output}")
+            return {"decision": "end"}
+
+        decision = str(payload.get("decision", "")).strip().lower()
+        normalized_decision = GUARDRAIL_DECISION_ALIASES.get(decision)
+
+        if normalized_decision is None:
+            if self.enable_debug:
+                print(f"[Guardrails Parse Error] invalid decision={decision!r}; raw={raw_output}")
+            return {"decision": "end"}
+
+        return {"decision": normalized_decision}
+
     def _build_processing_graph(self):
         """Construct the state machine graph for the RAG pipeline."""
         builder = StateGraph(State)
@@ -318,6 +354,7 @@ class RAG:
         """
         Decide whether to use graph retrieval or general LLM knowledge.
         Uses fast model (gpt-5-nano) for quick decision.
+        Expects JSON response with decision field ("generate" or "end").
 
         Args:
             state: Current pipeline state
@@ -327,26 +364,23 @@ class RAG:
         """
         guardrails_chain = self.guard_rails_template | self.fast_llm | StrOutputParser()
 
-        guardrail_output = (
-            await self._ainvoke_with_retry(
-                guardrails_chain,
-                {"user_question": state["user_question"]},
-                config=self._get_invoke_config(
-                    trace_id=state["trace_id"],
-                    tags=["knowledge_graph", "guardrails"],
-                    run_name="Guardrails",
-                    handler=state.get("callback_handler"),
-                ),
-            )
-            .strip()
-            .lower()
+        guardrail_output = await self._ainvoke_with_retry(
+            guardrails_chain,
+            {"user_question": state["user_question"]},
+            config=self._get_invoke_config(
+                trace_id=state["trace_id"],
+                tags=["knowledge_graph", "guardrails"],
+                run_name="Guardrails",
+                handler=state.get("callback_handler"),
+            ),
         )
+        guardrail_result = self._parse_guardrail_output(guardrail_output)
 
-        next_node = "generate_cypher" if "generate" in guardrail_output else "end"
+        next_node = guardrail_result["decision"]
 
         return {
             "next_node": next_node,
-            "guardrail_decision": guardrail_output,
+            "guardrail_decision": guardrail_result["decision"],
         }
 
     def return_none(self, state: State):
@@ -364,6 +398,30 @@ class RAG:
             "answer": "W bazie danych nie ma informacji",
             "context": [],
             "generated_cypher": None,
+        }
+
+    def _format_response(self, result: Dict[str, Any]) -> Dict[str, Any]:
+        """Convert graph output into the public response payload."""
+        if result.get("answer") == "W bazie danych nie ma informacji":
+            return {
+                "answer": "W bazie danych nie ma informacji",
+                "metadata": {
+                    "guardrail_decision": result.get("guardrail_decision"),
+                    "cypher_query": None,
+                    "context": [],
+                },
+            }
+
+        context_data = result.get("context", [])
+        context_json = json.dumps(context_data, ensure_ascii=False, indent=2)
+
+        return {
+            "answer": context_json,
+            "metadata": {
+                "guardrail_decision": result.get("guardrail_decision"),
+                "cypher_query": result.get("generated_cypher"),
+                "context": context_data,
+            },
         }
 
     def invoke(self, message: str, session_id: str = "default") -> Dict[str, Any]:
@@ -411,24 +469,4 @@ class RAG:
         except asyncio.TimeoutError as exc:
             raise TimeoutError(RAG.GRAPH_PIPELINE_TIMEOUT_MESSAGE) from exc
 
-        if result.get("answer") == "W bazie danych nie ma informacji":
-            return {
-                "answer": "W bazie danych nie ma informacji",
-                "metadata": {
-                    "guardrail_decision": result.get("guardrail_decision"),
-                    "cypher_query": None,
-                    "context": [],
-                },
-            }
-
-        context_data = result.get("context", [])
-        context_json = json.dumps(context_data, ensure_ascii=False, indent=2)
-
-        return {
-            "answer": context_json,
-            "metadata": {
-                "guardrail_decision": result.get("guardrail_decision"),
-                "cypher_query": result.get("generated_cypher"),
-                "context": context_data,
-            },
-        }
+        return self._format_response(result)

--- a/src/mcp_server/tools/knowledge_graph/rag.py
+++ b/src/mcp_server/tools/knowledge_graph/rag.py
@@ -22,6 +22,7 @@ except ImportError:
     RateLimitError = Exception
 
 from ....config.config import get_config
+from ....config.messages import GRAPH_PIPELINE_TIMEOUT_MESSAGE, LLM_CALL_TIMEOUT_MESSAGE
 from .graph_visualizer import GraphVisualizer
 from .state import State
 
@@ -45,11 +46,6 @@ class LLMProvider(Enum):
 
 class RAG:
     """Retrieval-Augmented Generation system with Neo4j graph database backend."""
-
-    GRAPH_PIPELINE_TIMEOUT_MESSAGE = (
-        "The knowledge graph pipeline exceeded the maximum allowed wait time."
-    )
-    LLM_CALL_TIMEOUT_MESSAGE = "The language model request exceeded the maximum allowed wait time."
 
     def __init__(
         self,
@@ -126,54 +122,81 @@ class RAG:
         try:
             return await chain.ainvoke(inputs, config=config)
         except TimeoutError as exc:
-            raise TimeoutError(RAG.LLM_CALL_TIMEOUT_MESSAGE) from exc
+            raise TimeoutError(LLM_CALL_TIMEOUT_MESSAGE) from exc
+
+    @staticmethod
+    def _available_provider_keys() -> Dict[LLMProvider, str]:
+        """Return providers that have a non-empty API key in the environment."""
+        key_by_provider = {
+            LLMProvider.OPENAI: os.environ.get("OPENAI_API_KEY", "").strip(),
+            LLMProvider.DEEPSEEK: os.environ.get("DEEPSEEK_API_KEY", "").strip(),
+            LLMProvider.GOOGLE: os.environ.get("GOOGLE_API_KEY", "").strip(),
+        }
+        return {provider: key for provider, key in key_by_provider.items() if key}
 
     def _get_configured_providers(self) -> List[LLMProvider]:
         """Read provider fallback order from config and filter by available API keys."""
-        config = self.config
-        fallback_order = getattr(config.llm, "provider_fallback_order", [])
-        openai_key = os.environ.get("OPENAI_API_KEY", "").strip()
-        deepseek_key = os.environ.get("DEEPSEEK_API_KEY", "").strip()
-        google_key = os.environ.get("GOOGLE_API_KEY", "").strip()
+        available = self._available_provider_keys()
+        fallback_order = getattr(self.config.llm, "provider_fallback_order", [])
 
-        providers = []
+        providers: List[LLMProvider] = []
         for provider_name in fallback_order:
             provider_name_lower = str(provider_name).lower().strip()
-            if provider_name_lower == "openai":
-                if openai_key:
-                    providers.append(LLMProvider.OPENAI)
-            elif provider_name_lower == "deepseek":
-                if deepseek_key:
-                    providers.append(LLMProvider.DEEPSEEK)
-            elif provider_name_lower == "google":
-                if google_key:
-                    providers.append(LLMProvider.GOOGLE)
+            if provider_name_lower == "openai" and LLMProvider.OPENAI in available:
+                providers.append(LLMProvider.OPENAI)
+            elif provider_name_lower == "deepseek" and LLMProvider.DEEPSEEK in available:
+                providers.append(LLMProvider.DEEPSEEK)
+            elif provider_name_lower == "google" and LLMProvider.GOOGLE in available:
+                providers.append(LLMProvider.GOOGLE)
 
-        return providers if providers else [LLMProvider.OPENAI]  # Fallback to OpenAI
+        if providers:
+            return providers
 
-    def _get_model(self, provider: LLMProvider):
+        # No config match (e.g. only GOOGLE_API_KEY while order lists openai only).
+        default_chain = (LLMProvider.OPENAI, LLMProvider.DEEPSEEK, LLMProvider.GOOGLE)
+        return [provider for provider in default_chain if provider in available]
+
+    def _get_model(self, provider: LLMProvider, *, use_accurate: bool = False):
         """Create LLM client for the specified provider."""
+        model_cfg = (
+            self.config.llm.accurate_model if use_accurate else self.config.llm.fast_model
+        )
+
         if provider == LLMProvider.OPENAI:
+            api_key = os.environ.get("OPENAI_API_KEY", "").strip() or self.api_key
             return BaseChatOpenAI(
-                model=self.config.llm.fast_model.name,
-                api_key=self.api_key,
-                temperature=self.config.llm.fast_model.temperature,
+                model=model_cfg.name,
+                api_key=api_key,
+                temperature=model_cfg.temperature,
                 timeout=self.llm_timeout_sec,
             )
-        elif provider == LLMProvider.DEEPSEEK:
-            # TODO: Implement DeepSeek client initialization when DEEPSEEK_API_KEY is available
-            raise NotImplementedError("DeepSeek provider not yet implemented")
-        elif provider == LLMProvider.GOOGLE:
-            # TODO: Implement Google Gemini client initialization when GOOGLE_API_KEY is available
-            raise NotImplementedError("Google provider not yet implemented")
-        else:
-            raise ValueError(f"Unknown provider: {provider}")
+        if provider == LLMProvider.DEEPSEEK:
+            api_key = os.environ.get("DEEPSEEK_API_KEY", "").strip() or self.api_key
+            return BaseChatOpenAI(
+                model=model_cfg.name,
+                api_key=api_key,
+                base_url=self.config.llm.deepseek.base_url,
+                temperature=model_cfg.temperature,
+                timeout=self.llm_timeout_sec,
+            )
+        if provider == LLMProvider.GOOGLE:
+            api_key = os.environ.get("GOOGLE_API_KEY", "").strip() or self.api_key
+            return ChatGoogleGenerativeAI(
+                model=self.config.llm.gemini.name,
+                google_api_key=api_key,
+                temperature=1.0,
+                timeout=self.llm_timeout_sec,
+            )
+
+        raise ValueError(f"Unknown provider: {provider}")
 
     async def _ainvoke_with_provider_fallback(
         self,
         template: PromptTemplate,
         inputs: Dict[str, Any],
         config: dict,
+        *,
+        use_accurate: bool = False,
     ) -> str:
         """
         Invoke LLM chain with provider fallback (OpenAI → DeepSeek → Google).
@@ -192,6 +215,12 @@ class RAG:
             RuntimeError: When all configured providers are exhausted
         """
         providers = self._get_configured_providers()
+        if not providers:
+            raise RuntimeError(
+                "No LLM provider available. Set OPENAI_API_KEY, "
+                "DEEPSEEK_API_KEY, or GOOGLE_API_KEY."
+            )
+
         last_error = None
 
         for provider in providers:
@@ -199,7 +228,7 @@ class RAG:
                 if self.enable_debug:
                     print(f"[Fallback] Trying provider: {provider.value}")
 
-                model = self._get_model(provider)
+                model = self._get_model(provider, use_accurate=use_accurate)
                 chain = template | model | StrOutputParser()
 
                 result = await self._ainvoke_with_retry(chain, inputs, config)
@@ -280,6 +309,8 @@ class RAG:
         """Raise if generated Cypher contains write-operation keywords."""
         clean = re.sub(r"//[^\n]*", "", query)
         clean = re.sub(r"/\*.*?\*/", "", clean, flags=re.DOTALL)
+        clean = re.sub(r"'(?:[^'\\]|\\.)*'", " ", clean)
+        clean = re.sub(r'"(?:[^"\\]|\\.)*"', " ", clean)
 
         tokens = set(re.findall(r"\b[A-Z]+\b", clean.upper()))
         blocked = tokens & FORBIDDEN_CLAUSES
@@ -377,7 +408,7 @@ class RAG:
         print(f"[Schema used for Cypher generation] ({len(schema)} chars):\n{schema or '(empty)'}")
 
         generated_cypher = await self._ainvoke_with_provider_fallback(
-                self.generate_cypher_template,
+            self.generate_cypher_template,
             {
                 "user_question": state["user_question"],
                 "schema": schema,
@@ -388,6 +419,7 @@ class RAG:
                 run_name="Generate Cypher",
                 handler=state.get("callback_handler"),
             ),
+            use_accurate=True,
         )
 
         return {"generated_cypher": generated_cypher}
@@ -437,7 +469,7 @@ class RAG:
             Updated state with next node decision
         """
         guardrail_output = await self._ainvoke_with_provider_fallback(
-                self.guard_rails_template,
+            self.guard_rails_template,
             {"user_question": state["user_question"]},
             config=self._get_invoke_config(
                 trace_id=state["trace_id"],
@@ -540,6 +572,6 @@ class RAG:
                 timeout=self.graph_timeout_sec,
             )
         except asyncio.TimeoutError as exc:
-            raise TimeoutError(RAG.GRAPH_PIPELINE_TIMEOUT_MESSAGE) from exc
+            raise TimeoutError(GRAPH_PIPELINE_TIMEOUT_MESSAGE) from exc
 
         return self._format_response(result)

--- a/src/mcp_server/tools/knowledge_graph/rag.py
+++ b/src/mcp_server/tools/knowledge_graph/rag.py
@@ -2,7 +2,8 @@ import asyncio
 import json
 import os
 import re
-from typing import Any, Dict
+from enum import Enum
+from typing import Any, Dict, List
 
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import PromptTemplate
@@ -12,6 +13,13 @@ from langchain_openai.chat_models.base import BaseChatOpenAI
 from langfuse.langchain import CallbackHandler
 from langgraph.graph import END, START, StateGraph
 from tenacity import retry, stop_after_attempt, wait_exponential, wait_random
+
+try:
+    from openai import APIError, APITimeoutError, RateLimitError
+except ImportError:
+    APIError = Exception
+    APITimeoutError = TimeoutError
+    RateLimitError = Exception
 
 from ....config.config import get_config
 from .graph_visualizer import GraphVisualizer
@@ -23,6 +31,16 @@ GUARDRAIL_DECISION_ALIASES = {
     "generate_cypher": "generate_cypher",
     "end": "end",
 }
+
+RETRYABLE_EXCEPTIONS = (APIError, APITimeoutError, RateLimitError, TimeoutError)
+
+
+class LLMProvider(Enum):
+    """Available LLM providers for fallback chain."""
+
+    OPENAI = "openai"
+    DEEPSEEK = "deepseek"
+    GOOGLE = "google"
 
 
 class RAG:
@@ -60,41 +78,11 @@ class RAG:
         config = get_config()
 
         self.graph_timeout_sec = graph_timeout_sec
+        self.llm_timeout_sec = llm_timeout_sec
         self.api_key = api_key
+        self.config = config
         self.enable_debug = enable_debug if enable_debug is not None else config.rag.enable_debug
         self.max_results = max_results if max_results is not None else config.rag.max_results
-
-        # Check for non-empty API keys
-        openai_key = os.environ.get("OPENAI_API_KEY", "").strip()
-        deepseek_key = os.environ.get("DEEPSEEK_API_KEY", "").strip()
-
-        if openai_key or deepseek_key:
-            self.fast_llm = BaseChatOpenAI(
-                model=config.llm.fast_model.name,
-                api_key=api_key,
-                temperature=config.llm.fast_model.temperature,
-                timeout=llm_timeout_sec,
-            )
-
-            self.cypher_llm = BaseChatOpenAI(
-                model=config.llm.accurate_model.name,
-                api_key=api_key,
-                temperature=config.llm.accurate_model.temperature,
-                timeout=llm_timeout_sec,
-            )
-        else:
-            self.fast_llm = ChatGoogleGenerativeAI(
-                model=config.llm.gemini.name,
-                google_api_key=api_key,
-                temperature=1.0,
-                timeout=llm_timeout_sec,
-            )
-            self.cypher_llm = ChatGoogleGenerativeAI(
-                model=config.llm.gemini.name,
-                google_api_key=api_key,
-                temperature=1.0,
-                timeout=llm_timeout_sec,
-            )
 
         self._initialize_prompt_templates()
 
@@ -134,25 +122,110 @@ class RAG:
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=2, max=10) + wait_random(0, 1),
     )
-    def _invoke_with_retry(self, chain: Any, inputs: Dict[str, Any], config: dict) -> Any:
-        # TODO: fallback chain OpenAI → DeepSeek → Google
-        # Currently only the OpenAI-compatible client path is wired at startup.
-        try:
-            return chain.invoke(inputs, config=config)
-        except TimeoutError as exc:
-            raise TimeoutError(RAG.LLM_CALL_TIMEOUT_MESSAGE) from exc
-
-    @retry(
-        stop=stop_after_attempt(3),
-        wait=wait_exponential(multiplier=1, min=2, max=10) + wait_random(0, 1),
-    )
     async def _ainvoke_with_retry(self, chain: Any, inputs: Dict[str, Any], config: dict) -> Any:
-        # TODO: fallback chain OpenAI → DeepSeek → Google
-        # Currently only the OpenAI-compatible client path is wired at startup.
         try:
             return await chain.ainvoke(inputs, config=config)
         except TimeoutError as exc:
             raise TimeoutError(RAG.LLM_CALL_TIMEOUT_MESSAGE) from exc
+
+    def _get_configured_providers(self) -> List[LLMProvider]:
+        """Read provider fallback order from config and filter by available API keys."""
+        config = self.config
+        fallback_order = getattr(config.llm, "provider_fallback_order", [])
+        openai_key = os.environ.get("OPENAI_API_KEY", "").strip()
+        deepseek_key = os.environ.get("DEEPSEEK_API_KEY", "").strip()
+        google_key = os.environ.get("GOOGLE_API_KEY", "").strip()
+
+        providers = []
+        for provider_name in fallback_order:
+            provider_name_lower = str(provider_name).lower().strip()
+            if provider_name_lower == "openai":
+                if openai_key:
+                    providers.append(LLMProvider.OPENAI)
+            elif provider_name_lower == "deepseek":
+                if deepseek_key:
+                    providers.append(LLMProvider.DEEPSEEK)
+            elif provider_name_lower == "google":
+                if google_key:
+                    providers.append(LLMProvider.GOOGLE)
+
+        return providers if providers else [LLMProvider.OPENAI]  # Fallback to OpenAI
+
+    def _get_model(self, provider: LLMProvider):
+        """Create LLM client for the specified provider."""
+        if provider == LLMProvider.OPENAI:
+            return BaseChatOpenAI(
+                model=self.config.llm.fast_model.name,
+                api_key=self.api_key,
+                temperature=self.config.llm.fast_model.temperature,
+                timeout=self.llm_timeout_sec,
+            )
+        elif provider == LLMProvider.DEEPSEEK:
+            # TODO: Implement DeepSeek client initialization when DEEPSEEK_API_KEY is available
+            raise NotImplementedError("DeepSeek provider not yet implemented")
+        elif provider == LLMProvider.GOOGLE:
+            # TODO: Implement Google Gemini client initialization when GOOGLE_API_KEY is available
+            raise NotImplementedError("Google provider not yet implemented")
+        else:
+            raise ValueError(f"Unknown provider: {provider}")
+
+    async def _ainvoke_with_provider_fallback(
+        self,
+        template: PromptTemplate,
+        inputs: Dict[str, Any],
+        config: dict,
+    ) -> str:
+        """
+        Invoke LLM chain with provider fallback (OpenAI → DeepSeek → Google).
+        Each provider gets up to 3 retries with exponential backoff.
+        Only retries on network/API errors; other errors fail fast.
+
+        Args:
+            template: PromptTemplate to use
+            inputs: Input dict for the chain
+            config: Invoke config with callbacks/metadata
+
+        Returns:
+            LLM output string
+
+        Raises:
+            RuntimeError: When all configured providers are exhausted
+        """
+        providers = self._get_configured_providers()
+        last_error = None
+
+        for provider in providers:
+            try:
+                if self.enable_debug:
+                    print(f"[Fallback] Trying provider: {provider.value}")
+
+                model = self._get_model(provider)
+                chain = template | model | StrOutputParser()
+
+                result = await self._ainvoke_with_retry(chain, inputs, config)
+
+                if self.enable_debug:
+                    print(f"[Fallback] Success with {provider.value}")
+                return result
+
+            except RETRYABLE_EXCEPTIONS as exc:
+                # Network/API errors → try next provider
+                last_error = exc
+                if self.enable_debug:
+                    print(f"[Fallback] {provider.value} failed (retryable): {exc}; trying next...")
+                continue
+
+            except Exception as exc:
+                # Other errors (config, not-implemented, etc) → fail fast
+                if self.enable_debug:
+                    print(f"[Fallback] {provider.value} failed (non-retryable): {exc}")
+                raise
+
+        # All providers exhausted
+        raise RuntimeError(
+            f"All LLM providers exhausted. Last error: {last_error}. "
+            f"Configured providers: {[p.value for p in providers]}"
+        )
 
     @property
     def schema(self):
@@ -292,6 +365,7 @@ class RAG:
         """
         Generate CYPHER query from user question using database schema.
         Uses better model (gpt-5-mini) for complex Cypher generation.
+        Tries providers in configured fallback order.
 
         Args:
             state: Current pipeline state
@@ -302,9 +376,8 @@ class RAG:
         schema = self.schema
         print(f"[Schema used for Cypher generation] ({len(schema)} chars):\n{schema or '(empty)'}")
 
-        chain = self.generate_cypher_template | self.cypher_llm | StrOutputParser()
-        generated_cypher = await self._ainvoke_with_retry(
-            chain,
+        generated_cypher = await self._ainvoke_with_provider_fallback(
+                self.generate_cypher_template,
             {
                 "user_question": state["user_question"],
                 "schema": schema,
@@ -355,6 +428,7 @@ class RAG:
         Decide whether to use graph retrieval or general LLM knowledge.
         Uses fast model (gpt-5-nano) for quick decision.
         Expects JSON response with decision field ("generate" or "end").
+        Tries providers in configured fallback order.
 
         Args:
             state: Current pipeline state
@@ -362,10 +436,8 @@ class RAG:
         Returns:
             Updated state with next node decision
         """
-        guardrails_chain = self.guard_rails_template | self.fast_llm | StrOutputParser()
-
-        guardrail_output = await self._ainvoke_with_retry(
-            guardrails_chain,
+        guardrail_output = await self._ainvoke_with_provider_fallback(
+                self.guard_rails_template,
             {"user_question": state["user_question"]},
             config=self._get_invoke_config(
                 trace_id=state["trace_id"],
@@ -435,6 +507,7 @@ class RAG:
         Returns:
             Dictionary with context from graph or "W bazie danych nie ma informacji"
         """
+        """Synchronous wrapper for CLI/tests only; do not call from an active event loop."""
         return asyncio.run(self.ainvoke(message, session_id=session_id))
 
     async def ainvoke(

--- a/src/mcp_server/tools/knowledge_graph/state.py
+++ b/src/mcp_server/tools/knowledge_graph/state.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from langchain_core.documents import Document
 from langgraph.graph import MessagesState
@@ -14,3 +14,4 @@ class State(MessagesState):
     generated_cypher: Optional[str] = None
     guardrail_decision: Optional[str] = None
     trace_id: Optional[str] = None
+    callback_handler: Optional[Any] = None

--- a/src/scripts/data_pipeline/llm_pipe.py
+++ b/src/scripts/data_pipeline/llm_pipe.py
@@ -16,10 +16,11 @@ class PipeState(MessagesState):
 class LLMPipe:
     def __init__(self, api_key: str = None, nodes: List[str] = None, relations: List[str] = None):
         config = get_config()
-        BaseChatOpenAI(
+        self.model = BaseChatOpenAI(
             model=config.llm.accurate_model.name,
             api_key=api_key,
             temperature=config.llm.accurate_model.temperature,
+            timeout=30.0,
         )
         self._initialize_prompt_templates()
         self.nodes = nodes

--- a/src/topwr_api/server.py
+++ b/src/topwr_api/server.py
@@ -1,5 +1,6 @@
 """FastAPI application for ToPWR MCP integration."""
 
+import asyncio
 import logging
 import os
 import uuid
@@ -13,6 +14,7 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI
 
 from ..config.config import get_config
+from ..mcp_server.tools.knowledge_graph.rag import RAG
 from .models import ChatRequest, ChatResponse, MessageRole
 from .session_manager import SessionManager
 
@@ -45,12 +47,14 @@ if clarin_api_key:
         model_name=config.llm.clarin.name,
         base_url=config.llm.clarin.base_url,
         api_key=clarin_api_key,
+        timeout=30.0,
     )
 elif google_api_key:
     llm = ChatGoogleGenerativeAI(
         model=config.llm.gemini.name,
         google_api_key=google_api_key,
         temperature=1.0,
+        timeout=30.0,
     )
 else:
     logger.warning("No LLM API key found. Chat will return raw knowledge graph data.")
@@ -125,7 +129,12 @@ async def query_mcp_knowledge_graph(user_input: str, trace_id: str = None) -> st
         return "\n".join(item.text for item in result.content if hasattr(item, "text"))
 
 
-async def generate_final_answer(user_input: str, kg_data: str, history: str = "") -> str:
+async def generate_final_answer(
+    user_input: str,
+    kg_data: str,
+    history: str = "",
+    llm_timeout_sec: float = 30.0,
+) -> str:
     """
     Generate a final answer using the LLM with knowledge graph context.
 
@@ -133,6 +142,7 @@ async def generate_final_answer(user_input: str, kg_data: str, history: str = ""
         user_input: Original user question
         kg_data: Knowledge graph data from MCP server
         history: Recent conversation history as a formatted string
+        llm_timeout_sec: Max seconds for the final LLM HTTP call
 
     Returns:
         LLM-generated answer
@@ -144,7 +154,13 @@ async def generate_final_answer(user_input: str, kg_data: str, history: str = ""
         user_input=user_input, data=kg_data, history=history or "(no prior conversation)"
     )
 
-    response = await llm.ainvoke(final_prompt)
+    try:
+        response = await asyncio.wait_for(
+            llm.ainvoke(final_prompt),
+            timeout=llm_timeout_sec,
+        )
+    except asyncio.TimeoutError as exc:
+        raise TimeoutError(RAG.LLM_CALL_TIMEOUT_MESSAGE) from exc
     return response.content
 
 

--- a/src/topwr_api/server.py
+++ b/src/topwr_api/server.py
@@ -14,7 +14,7 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI
 
 from ..config.config import get_config
-from ..mcp_server.tools.knowledge_graph.rag import RAG
+from ..config.messages import LLM_CALL_TIMEOUT_MESSAGE
 from .models import ChatRequest, ChatResponse, MessageRole
 from .session_manager import SessionManager
 
@@ -160,7 +160,7 @@ async def generate_final_answer(
             timeout=llm_timeout_sec,
         )
     except asyncio.TimeoutError as exc:
-        raise TimeoutError(RAG.LLM_CALL_TIMEOUT_MESSAGE) from exc
+        raise TimeoutError(LLM_CALL_TIMEOUT_MESSAGE) from exc
     return response.content
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3709,6 +3709,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "ruff" },
+    { name = "tenacity" },
     { name = "uvicorn" },
 ]
 
@@ -3730,6 +3731,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.14.1" },
+    { name = "tenacity", specifier = ">=9.1.2" },
     { name = "uvicorn", specifier = ">=0.34.0" },
 ]
 


### PR DESCRIPTION
Review follow-up (fix: address PR review)
- Share timeout messages via `src/config/messages.py` (fix API image import)
- Implement DeepSeek/Google provider fallback; fix provider selection without OpenAI key
- Use `accurate_model` for Cypher, `fast_model` for guardrails
- Strip quoted strings before Cypher write-keyword validation

This PR improves safety and reliability in the knowledge-graph RAG pipeline:

Cypher write-operation guardrail
Validates generated Cypher before Neo4jGraph.query().
Blocks mutation keywords such as CREATE, MERGE, DELETE, DETACH, SET, REMOVE, and DROP.
Strips comments first and inspects uppercase tokens, so unsafe queries fail before execution with a controlled error.
LLM call timeouts
Adds explicit timeout values to LangChain LLM clients (BaseChatOpenAI / ChatGoogleGenerativeAI).
Wraps async pipeline entry points with asyncio.wait_for() so a single request cannot hang indefinitely.
Uses a separate wall-clock budget for the full LangGraph run where applicable.
LLM retry with exponential backoff
Wraps chain.invoke() / chain.ainvoke() used by generate_cypher and guardrails_system with Tenacity.
Uses 3 attempts with exponential backoff and jitter for transient failures such as rate limits and temporary API errors.
Provider fallback is intentionally left as follow-up TODO; startup-time provider selection remains unchanged.
Guardrail output as strict JSON
Guardrail prompt now requires strict JSON output: {decision: generate_cypher} or {decision: end}.
Parser strips optional code fences, extracts JSON from noisy text, parses it safely, and normalizes decisions via aliases.
Parse failures default to end, keeping LangGraph routing aligned with guardrail_decision.