### PR TITLE
fix: harden LLM and Cypher execution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ GOOGLE_API_KEY=
 # CLARIN LLM API key (optional, used by API & client)
 CLARIN_API_KEY=
 
+# LLM request timeout in seconds
+LLM_TIMEOUT_SECONDS=30
+
 
 ########################################
 # Langfuse Observability

--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ GOOGLE_API_KEY=
 # CLARIN LLM API key (optional, used by API & client)
 CLARIN_API_KEY=
 
+# LLM request timeout in seconds
+LLM_TIMEOUT_SECONDS=30
+
 
 ########################################
 # Langfuse Observability

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pydantic>=2.10.0",
     "pyyaml>=6.0.0",
     "ruff>=0.14.1",
+    "tenacity>=9.1.2",
     "uvicorn>=0.34.0",
 ]
 

--- a/src/llm_hardening.py
+++ b/src/llm_hardening.py
@@ -1,0 +1,21 @@
+"""Shared timeout settings for LLM calls."""
+
+from __future__ import annotations
+
+import os
+
+DEFAULT_LLM_TIMEOUT_SECONDS = 30.0
+
+
+def get_llm_timeout_seconds() -> float:
+    """Return the configured positive LLM timeout in seconds."""
+    raw_value = os.getenv("LLM_TIMEOUT_SECONDS", "").strip()
+    if not raw_value:
+        return DEFAULT_LLM_TIMEOUT_SECONDS
+
+    try:
+        timeout = float(raw_value)
+    except ValueError:
+        return DEFAULT_LLM_TIMEOUT_SECONDS
+
+    return timeout if timeout > 0 else DEFAULT_LLM_TIMEOUT_SECONDS

--- a/src/mcp_client/client.py
+++ b/src/mcp_client/client.py
@@ -11,10 +11,12 @@ from langchain_openai.chat_models.base import BaseChatOpenAI
 from pydantic import SecretStr
 
 from ..config.config import get_config
+from ..llm_hardening import get_llm_timeout_seconds
 
 load_dotenv()
 
 config = get_config()
+llm_timeout_seconds = get_llm_timeout_seconds()
 mcp_host = os.getenv("MCP_HOST", config.servers.mcp.host)
 mcp_port = os.getenv("MCP_PORT", config.servers.mcp.port)
 mcp_transport = config.servers.mcp.transport
@@ -31,18 +33,21 @@ if openai_api_key:
         model=config.llm.accurate_model.name,
         api_key=SecretStr(openai_api_key),
         temperature=config.llm.accurate_model.temperature,
+        timeout=llm_timeout_seconds,
     )
 elif clarin_api_key:
     llm = ChatOpenAI(
         model_name=config.llm.clarin.name,
         base_url=config.llm.clarin.base_url,
         api_key=clarin_api_key,
+        timeout=llm_timeout_seconds,
     )
 elif google_api_key:
     llm = ChatGoogleGenerativeAI(
         model=config.llm.gemini.name,
         google_api_key=google_api_key,
         temperature=1.0,
+        request_timeout=llm_timeout_seconds,
     )
 else:
     raise ValueError(
@@ -130,7 +135,10 @@ async def query_knowledge_graph(user_input: str, trace_id: str = None):
     if handler is not None:
         invoke_config["callbacks"] = [handler]
 
-    llm_response = await llm.ainvoke(final_prompt, config=invoke_config)
+    llm_response = await asyncio.wait_for(
+        llm.ainvoke(final_prompt, config=invoke_config),
+        timeout=llm_timeout_seconds,
+    )
 
     print(llm_response.content)
     return llm_response

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -1,14 +1,17 @@
+import asyncio
 import os
 
 from dotenv import load_dotenv
 from fastmcp import FastMCP
 
 from ..config.config import get_config
+from ..llm_hardening import get_llm_timeout_seconds
 from .tools.knowledge_graph.rag import RAG
 
 load_dotenv()
 
 mcp = FastMCP("SOLVRO MCP")
+llm_timeout_seconds = get_llm_timeout_seconds()
 
 rag = None
 langfuse = None
@@ -77,7 +80,10 @@ async def knowledge_graph_tool(user_input: str, trace_id: str = None) -> str:
     if rag is None:
         return "Error: RAG not initialized. Please start the server first."
 
-    result = await rag.ainvoke(message=user_input, trace_id=trace_id, callback_handler=handler)
+    result = await asyncio.wait_for(
+        rag.ainvoke(message=user_input, trace_id=trace_id, callback_handler=handler),
+        timeout=llm_timeout_seconds,
+    )
 
     metadata = result.get("metadata", {})
     print(f"[Guardrail decision] {metadata.get('guardrail_decision')}")

--- a/src/mcp_server/tools/knowledge_graph/rag.py
+++ b/src/mcp_server/tools/knowledge_graph/rag.py
@@ -1,5 +1,7 @@
+import asyncio
 import json
 import os
+import re
 from typing import Any, Dict
 
 from langchain_core.output_parsers import StrOutputParser
@@ -9,10 +11,69 @@ from langchain_neo4j import Neo4jGraph
 from langchain_openai.chat_models.base import BaseChatOpenAI
 from langfuse.langchain import CallbackHandler
 from langgraph.graph import END, START, StateGraph
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_random_exponential
 
 from ....config.config import get_config
+from ....llm_hardening import get_llm_timeout_seconds
 from .graph_visualizer import GraphVisualizer
 from .state import State
+
+WRITE_CYPHER_KEYWORDS = frozenset(
+    {
+        "CREATE",
+        "DELETE",
+        "DETACH",
+        "DROP",
+        "FOREACH",
+        "LOAD",
+        "MERGE",
+        "REMOVE",
+        "SET",
+    }
+)
+READ_ONLY_START_RE = re.compile(r"^\s*(MATCH|OPTIONAL\s+MATCH|WITH|CALL|UNWIND)\b", re.IGNORECASE)
+STRING_LITERAL_RE = re.compile(r"'(?:\\.|[^'\\])*'|\"(?:\\.|[^\"\\])*\"")
+COMMENT_RE = re.compile(r"//.*?$|/\*.*?\*/", re.MULTILINE | re.DOTALL)
+
+
+class UnsafeCypherQueryError(ValueError):
+    """Raised when generated Cypher contains a mutating operation."""
+
+
+def _scrub_cypher_for_validation(cypher_query: str) -> str:
+    without_comments = COMMENT_RE.sub(" ", cypher_query)
+    return STRING_LITERAL_RE.sub(" ", without_comments)
+
+
+def validate_read_only_cypher(cypher_query: str) -> None:
+    """Reject Cypher that can mutate the graph before Neo4j execution."""
+    scrubbed_query = _scrub_cypher_for_validation(cypher_query).strip()
+    if not scrubbed_query:
+        raise UnsafeCypherQueryError("generated Cypher query is empty")
+
+    if ";" in scrubbed_query.rstrip(";"):
+        raise UnsafeCypherQueryError("multiple Cypher statements are not allowed")
+
+    if not READ_ONLY_START_RE.search(scrubbed_query):
+        raise UnsafeCypherQueryError("Cypher must start with a read-only clause")
+
+    normalized_query = scrubbed_query.upper()
+    for keyword in WRITE_CYPHER_KEYWORDS:
+        if re.search(rf"\b{keyword}\b", normalized_query):
+            raise UnsafeCypherQueryError(f"blocked mutating Cypher keyword: {keyword}")
+
+    if not re.search(r"\bRETURN\b", normalized_query):
+        raise UnsafeCypherQueryError("read-only Cypher must return data")
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_random_exponential(multiplier=1, max=8),
+    retry=retry_if_exception_type(Exception),
+    reraise=True,
+)
+def _invoke_llm_chain_with_retry(chain, payload: dict, invoke_config: dict) -> str:
+    return chain.invoke(payload, config=invoke_config)
 
 
 class RAG:
@@ -43,6 +104,7 @@ class RAG:
         self.api_key = api_key
         self.enable_debug = enable_debug if enable_debug is not None else config.rag.enable_debug
         self.max_results = max_results if max_results is not None else config.rag.max_results
+        self.llm_timeout_seconds = get_llm_timeout_seconds()
 
         # Check for non-empty API keys
         openai_key = os.environ.get("OPENAI_API_KEY", "").strip()
@@ -53,23 +115,27 @@ class RAG:
                 model=config.llm.fast_model.name,
                 api_key=api_key,
                 temperature=config.llm.fast_model.temperature,
+                timeout=self.llm_timeout_seconds,
             )
 
             self.cypher_llm = BaseChatOpenAI(
                 model=config.llm.accurate_model.name,
                 api_key=api_key,
                 temperature=config.llm.accurate_model.temperature,
+                timeout=self.llm_timeout_seconds,
             )
         else:
             self.fast_llm = ChatGoogleGenerativeAI(
                 model=config.llm.gemini.name,
                 google_api_key=api_key,
                 temperature=1.0,
+                request_timeout=self.llm_timeout_seconds,
             )
             self.cypher_llm = ChatGoogleGenerativeAI(
                 model=config.llm.gemini.name,
                 google_api_key=api_key,
                 temperature=1.0,
+                request_timeout=self.llm_timeout_seconds,
             )
 
         self._initialize_prompt_templates()
@@ -209,12 +275,13 @@ class RAG:
         print(f"[Schema used for Cypher generation] ({len(schema)} chars):\n{schema or '(empty)'}")
 
         chain = self.generate_cypher_template | self.cypher_llm | StrOutputParser()
-        generated_cypher = chain.invoke(
+        generated_cypher = _invoke_llm_chain_with_retry(
+            chain,
             {
                 "user_question": state["user_question"],
                 "schema": schema,
             },
-            config=self._get_invoke_config(
+            self._get_invoke_config(
                 trace_id=state["trace_id"],
                 tags=["knowledge_graph", "generated_cypher"],
                 run_name="Generate Cypher",
@@ -240,9 +307,16 @@ class RAG:
             if "LIMIT" not in cypher_query.upper():
                 cypher_query = f"{cypher_query.rstrip(';')} LIMIT {self.max_results}"
 
+            validate_read_only_cypher(cypher_query)
             response = self.database.query(cypher_query)
 
             return {"context": response}
+
+        except UnsafeCypherQueryError as e:
+            error_msg = f"Blocked unsafe Cypher query: {e}"
+            if self.enable_debug:
+                print(f"[Query Guardrail] {error_msg}")
+            return {"context": [], "generated_cypher": error_msg}
 
         except Exception as e:
             error_msg = str(e)
@@ -266,9 +340,10 @@ class RAG:
         guardrails_chain = self.guard_rails_template | self.fast_llm | StrOutputParser()
 
         guardrail_output = (
-            guardrails_chain.invoke(
+            _invoke_llm_chain_with_retry(
+                guardrails_chain,
                 {"user_question": state["user_question"]},
-                config=self._get_invoke_config(
+                self._get_invoke_config(
                     trace_id=state["trace_id"],
                     tags=["knowledge_graph", "guardrails"],
                     run_name="Guardrails",
@@ -356,7 +431,10 @@ class RAG:
         """
         self.handler = callback_handler
 
-        result = await self.graph.ainvoke({"user_question": message, "trace_id": trace_id})
+        result = await asyncio.wait_for(
+            self.graph.ainvoke({"user_question": message, "trace_id": trace_id}),
+            timeout=self.llm_timeout_seconds,
+        )
 
         if result.get("answer") == "W bazie danych nie ma informacji":
             return {

--- a/src/topwr_api/server.py
+++ b/src/topwr_api/server.py
@@ -1,5 +1,6 @@
 """FastAPI application for ToPWR MCP integration."""
 
+import asyncio
 import logging
 import os
 import uuid
@@ -13,6 +14,7 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI
 
 from ..config.config import get_config
+from ..llm_hardening import get_llm_timeout_seconds
 from .models import ChatRequest, ChatResponse, MessageRole
 from .session_manager import SessionManager
 
@@ -26,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 # Configuration
 config = get_config()
+llm_timeout_seconds = get_llm_timeout_seconds()
 
 # MCP Client setup
 mcp_host = os.getenv("MCP_HOST", config.servers.mcp.host)
@@ -45,12 +48,14 @@ if clarin_api_key:
         model_name=config.llm.clarin.name,
         base_url=config.llm.clarin.base_url,
         api_key=clarin_api_key,
+        timeout=llm_timeout_seconds,
     )
 elif google_api_key:
     llm = ChatGoogleGenerativeAI(
         model=config.llm.gemini.name,
         google_api_key=google_api_key,
         temperature=1.0,
+        request_timeout=llm_timeout_seconds,
     )
 else:
     logger.warning("No LLM API key found. Chat will return raw knowledge graph data.")
@@ -144,7 +149,7 @@ async def generate_final_answer(user_input: str, kg_data: str, history: str = ""
         user_input=user_input, data=kg_data, history=history or "(no prior conversation)"
     )
 
-    response = await llm.ainvoke(final_prompt)
+    response = await asyncio.wait_for(llm.ainvoke(final_prompt), timeout=llm_timeout_seconds)
     return response.content
 
 

--- a/tests/test_cypher_guardrails.py
+++ b/tests/test_cypher_guardrails.py
@@ -1,0 +1,54 @@
+import pytest
+
+from src.mcp_server.tools.knowledge_graph.rag import (
+    UnsafeCypherQueryError,
+    validate_read_only_cypher,
+)
+
+
+def test_read_only_cypher_accepts_match_return_limit():
+    validate_read_only_cypher(
+        "MATCH (p:Person) WHERE toLower(p.title) CONTAINS toLower('kowalski') "
+        "RETURN p.title LIMIT 5"
+    )
+
+
+@pytest.mark.parametrize(
+    "cypher_query",
+    [
+        "MATCH (n) DETACH DELETE n RETURN n",
+        "CREATE (n:Person {title: 'x'}) RETURN n",
+        "MERGE (n:Person {title: 'x'}) RETURN n",
+        "MATCH (n) SET n.title = 'x' RETURN n",
+        "DROP INDEX course_title IF EXISTS",
+    ],
+)
+def test_read_only_cypher_rejects_mutating_keywords(cypher_query):
+    with pytest.raises(UnsafeCypherQueryError):
+        validate_read_only_cypher(cypher_query)
+
+
+def test_read_only_cypher_ignores_keywords_inside_strings_and_comments():
+    validate_read_only_cypher(
+        """
+        // DELETE should not count inside a comment
+        MATCH (c:Course)
+        WHERE c.title CONTAINS 'CREATE'
+        RETURN c.title
+        """
+    )
+
+
+def test_read_only_cypher_rejects_multiple_statements():
+    with pytest.raises(UnsafeCypherQueryError):
+        validate_read_only_cypher("MATCH (n) RETURN n; MATCH (m) RETURN m")
+
+
+def test_read_only_cypher_requires_return_data():
+    with pytest.raises(UnsafeCypherQueryError):
+        validate_read_only_cypher("MATCH (n)")
+
+
+def test_read_only_cypher_requires_read_only_start_clause():
+    with pytest.raises(UnsafeCypherQueryError):
+        validate_read_only_cypher("SHOW USERS RETURN user")

--- a/uv.lock
+++ b/uv.lock
@@ -3709,6 +3709,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "ruff" },
+    { name = "tenacity" },
     { name = "uvicorn" },
 ]
 
@@ -3730,6 +3731,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.14.1" },
+    { name = "tenacity", specifier = ">=9.1.2" },
     { name = "uvicorn", specifier = ">=0.34.0" },
 ]
 


### PR DESCRIPTION
## Summary
- add read-only Cypher validation before generated queries reach Neo4j
- apply a configurable LLM timeout to OpenAI/CLARIN/Gemini clients and wrap async LLM calls with `asyncio.wait_for`
- retry guardrail and Cypher generation chains with exponential backoff
- document `LLM_TIMEOUT_SECONDS` and add focused guardrail tests

## Verification
- `uv lock`
- `uv run ruff format src\llm_hardening.py src\mcp_client\client.py src\mcp_server\server.py src\mcp_server\tools\knowledge_graph\rag.py src\topwr_api\server.py tests\test_cypher_guardrails.py`
- `uv run ruff check src\llm_hardening.py src\mcp_client\client.py src\mcp_server\server.py src\mcp_server\tools\knowledge_graph\rag.py src\topwr_api\server.py tests\test_cypher_guardrails.py`
- `uv run --with pytest python -m pytest tests\test_cypher_guardrails.py -q`
- `git diff --check`

Fixes #28