### PR TITLE
Feat/langfuse integration + langfuse v3 

### DIFF
--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -2,6 +2,7 @@ import os
 
 from dotenv import load_dotenv
 from fastmcp import FastMCP
+from langfuse.langchain import CallbackHandler
 
 from ..config.config import get_config
 from .tools.knowledge_graph.rag import RAG
@@ -12,7 +13,6 @@ mcp = FastMCP("SOLVRO MCP")
 
 rag = None
 langfuse = None
-handler = None
 
 # Initialize Langfuse only if credentials are configured
 _langfuse_secret = os.getenv("LANGFUSE_SECRET_KEY")
@@ -22,14 +22,12 @@ _langfuse_host = os.getenv("LANGFUSE_HOST")
 if _langfuse_secret and _langfuse_public:
     try:
         from langfuse import Langfuse
-        from langfuse.langchain import CallbackHandler
 
         langfuse = Langfuse(
             secret_key=_langfuse_secret,
             public_key=_langfuse_public,
             host=_langfuse_host,
         )
-        handler = CallbackHandler()
     except Exception as e:
         print(f"Warning: Failed to initialize Langfuse: {e}")
 else:
@@ -63,13 +61,16 @@ def initialize_rag():
 
 
 @mcp.tool
-async def knowledge_graph_tool(user_input: str, trace_id: str = None) -> str:
+async def knowledge_graph_tool(
+    user_input: str, trace_id: str = None, session_id: str = None
+) -> str:
     """
     Query the knowledge graph with natural language.
 
     Args:
         user_input: User's question or query
         trace_id: Optional trace ID for tracking
+        session_id: Conversation session identifier
 
     Returns:
         AI-generated instructions based on knowledge graph data
@@ -77,7 +78,16 @@ async def knowledge_graph_tool(user_input: str, trace_id: str = None) -> str:
     if rag is None:
         return "Error: RAG not initialized. Please start the server first."
 
-    result = await rag.ainvoke(message=user_input, trace_id=trace_id, callback_handler=handler)
+    per_request_handler = None
+    if langfuse is not None:
+        per_request_handler = CallbackHandler(
+            trace_id=trace_id,
+            session_id=session_id,
+        )
+
+    result = await rag.ainvoke(
+        message=user_input, trace_id=trace_id, callback_handler=per_request_handler
+    )
 
     metadata = result.get("metadata", {})
     print(f"[Guardrail decision] {metadata.get('guardrail_decision')}")

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -1,3 +1,4 @@
+import atexit
 import os
 
 from dotenv import load_dotenv
@@ -28,6 +29,7 @@ if _langfuse_secret and _langfuse_public:
             public_key=_langfuse_public,
             host=_langfuse_host,
         )
+        atexit.register(langfuse.flush)
     except Exception as e:
         print(f"Warning: Failed to initialize Langfuse: {e}")
 else:
@@ -81,12 +83,14 @@ async def knowledge_graph_tool(
     per_request_handler = None
     if langfuse is not None:
         per_request_handler = CallbackHandler(
-            trace_id=trace_id,
-            session_id=session_id,
+            trace_context={"trace_id": trace_id} if trace_id else None,
         )
 
     result = await rag.ainvoke(
-        message=user_input, trace_id=trace_id, callback_handler=per_request_handler
+        message=user_input,
+        session_id=session_id,
+        trace_id=trace_id,
+        callback_handler=per_request_handler,
     )
 
     metadata = result.get("metadata", {})

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -69,8 +69,8 @@ async def knowledge_graph_tool(
 
     Args:
         user_input: User's question or query
-        trace_id: Optional trace ID for tracking
-        session_id: Conversation session identifier
+        trace_id: Trace identifier for this single request
+        session_id: Conversation session identifier from the calling API
 
     Returns:
         AI-generated instructions based on knowledge graph data

--- a/src/mcp_server/tools/knowledge_graph/rag.py
+++ b/src/mcp_server/tools/knowledge_graph/rag.py
@@ -87,20 +87,28 @@ class RAG:
         self.visualizer = GraphVisualizer()
         self.graph = self._build_processing_graph()
 
-    def _get_invoke_config(self, trace_id: str, tags: list, run_name: str, handler=None) -> dict:
+    def _get_invoke_config(
+        self,
+        trace_id: str,
+        tags: list,
+        run_name: str,
+        handler=None,
+        session_id: str = None,
+    ) -> dict:
         """
         Build invoke config with optional callbacks.
 
         Args:
-        trace_id: Used as Langfuse session_id in metadata
+        trace_id: Trace identifier for this single request
         tags: Langfuse tags applied to the spans
         run_name: Human-readable name for the span in Langfuse
         handler: Optional CallbackHandler
+        session_id: Conversation session identifier used as Langfuse session_id
 
         """
         config = {
             "metadata": {
-                "langfuse_session_id": trace_id,
+                "langfuse_session_id": session_id,
                 "langfuse_tags": tags,
                 "run_name": run_name,
             },
@@ -226,6 +234,7 @@ class RAG:
                 tags=["knowledge_graph", "generated_cypher"],
                 run_name="Generate Cypher",
                 handler=state.get("callback_handler"),
+                session_id=state.get("session_id"),
             ),
         )
 
@@ -281,6 +290,7 @@ class RAG:
                     tags=["knowledge_graph", "guardrails"],
                     run_name="Guardrails",
                     handler=state.get("callback_handler"),
+                    session_id=state.get("session_id"),
                 ),
             )
             .strip()
@@ -369,6 +379,7 @@ class RAG:
             {
                 "user_question": message,
                 "trace_id": trace_id,
+                "session_id": session_id,
                 "callback_handler": callback_handler,
             }
         )

--- a/src/mcp_server/tools/knowledge_graph/rag.py
+++ b/src/mcp_server/tools/knowledge_graph/rag.py
@@ -107,10 +107,10 @@ class RAG:
 
         """
         config = {
+            "run_name": run_name,
             "metadata": {
                 "langfuse_session_id": session_id,
                 "langfuse_tags": tags,
-                "run_name": run_name,
             },
         }
         if handler is not None:
@@ -230,7 +230,7 @@ class RAG:
                 "schema": schema,
             },
             config=self._get_invoke_config(
-                trace_id=state["trace_id"],
+                trace_id=state.get("trace_id"),
                 tags=["knowledge_graph", "generated_cypher"],
                 run_name="Generate Cypher",
                 handler=state.get("callback_handler"),
@@ -286,7 +286,7 @@ class RAG:
             guardrails_chain.invoke(
                 {"user_question": state["user_question"]},
                 config=self._get_invoke_config(
-                    trace_id=state["trace_id"],
+                    trace_id=state.get("trace_id"),
                     tags=["knowledge_graph", "guardrails"],
                     run_name="Guardrails",
                     handler=state.get("callback_handler"),

--- a/src/mcp_server/tools/knowledge_graph/rag.py
+++ b/src/mcp_server/tools/knowledge_graph/rag.py
@@ -88,7 +88,16 @@ class RAG:
         self.graph = self._build_processing_graph()
 
     def _get_invoke_config(self, trace_id: str, tags: list, run_name: str, handler=None) -> dict:
-        """Build invoke config with optional callbacks."""
+        """
+        Build invoke config with optional callbacks.
+
+        Args:
+        trace_id: Used as Langfuse session_id in metadata
+        tags: Langfuse tags applied to the spans
+        run_name: Human-readable name for the span in Langfuse
+        handler: Optional CallbackHandler
+
+        """
         config = {
             "metadata": {
                 "langfuse_session_id": trace_id,
@@ -350,6 +359,8 @@ class RAG:
         Args:
             message: User's question/input
             session_id: Session identifier for tracking
+            trace_id: Trace identifier for this single chat turn
+            callback_handler: Optional Langfuse CallbackHandler scoped to this request
 
         Returns:
             Dictionary with context from graph or "W bazie danych nie ma informacji"

--- a/src/mcp_server/tools/knowledge_graph/rag.py
+++ b/src/mcp_server/tools/knowledge_graph/rag.py
@@ -87,9 +87,7 @@ class RAG:
         self.visualizer = GraphVisualizer()
         self.graph = self._build_processing_graph()
 
-        self.handler = None
-
-    def _get_invoke_config(self, trace_id: str, tags: list, run_name: str) -> dict:
+    def _get_invoke_config(self, trace_id: str, tags: list, run_name: str, handler=None) -> dict:
         """Build invoke config with optional callbacks."""
         config = {
             "metadata": {
@@ -98,8 +96,8 @@ class RAG:
                 "run_name": run_name,
             },
         }
-        if self.handler is not None:
-            config["callbacks"] = [self.handler]
+        if handler is not None:
+            config["callbacks"] = [handler]
         return config
 
     @property
@@ -218,6 +216,7 @@ class RAG:
                 trace_id=state["trace_id"],
                 tags=["knowledge_graph", "generated_cypher"],
                 run_name="Generate Cypher",
+                handler=state.get("callback_handler"),
             ),
         )
 
@@ -272,6 +271,7 @@ class RAG:
                     trace_id=state["trace_id"],
                     tags=["knowledge_graph", "guardrails"],
                     run_name="Guardrails",
+                    handler=state.get("callback_handler"),
                 ),
             )
             .strip()
@@ -354,9 +354,13 @@ class RAG:
         Returns:
             Dictionary with context from graph or "W bazie danych nie ma informacji"
         """
-        self.handler = callback_handler
-
-        result = await self.graph.ainvoke({"user_question": message, "trace_id": trace_id})
+        result = await self.graph.ainvoke(
+            {
+                "user_question": message,
+                "trace_id": trace_id,
+                "callback_handler": callback_handler,
+            }
+        )
 
         if result.get("answer") == "W bazie danych nie ma informacji":
             return {

--- a/src/mcp_server/tools/knowledge_graph/state.py
+++ b/src/mcp_server/tools/knowledge_graph/state.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from langchain_core.documents import Document
 from langgraph.graph import MessagesState
@@ -14,3 +14,4 @@ class State(MessagesState):
     generated_cypher: Optional[str] = None
     guardrail_decision: Optional[str] = None
     trace_id: Optional[str] = None
+    callback_handler: Optional[Any] = None

--- a/src/mcp_server/tools/knowledge_graph/state.py
+++ b/src/mcp_server/tools/knowledge_graph/state.py
@@ -14,4 +14,5 @@ class State(MessagesState):
     generated_cypher: Optional[str] = None
     guardrail_decision: Optional[str] = None
     trace_id: Optional[str] = None
+    session_id: Optional[str] = None
     callback_handler: Optional[Any] = None

--- a/src/topwr_api/server.py
+++ b/src/topwr_api/server.py
@@ -156,7 +156,11 @@ async def query_mcp_knowledge_graph(
 
 
 async def generate_final_answer(
-    user_input: str, kg_data: str, history: str = "", callback_handler=None
+    user_input: str,
+    kg_data: str,
+    history: str = "",
+    callback_handler=None,
+    session_id: str = None,
 ) -> str:
     """
     Generate a final answer using the LLM with knowledge graph context.
@@ -166,6 +170,7 @@ async def generate_final_answer(
         kg_data: Knowledge graph data from MCP server
         history: Recent conversation history as a formatted string
         callback_handler: Optional Langfuse CallbackHandler
+        session_id: Conversation session identifier used as Langfuse session_id
 
     Returns:
         LLM-generated answer
@@ -177,7 +182,16 @@ async def generate_final_answer(
         user_input=user_input, data=kg_data, history=history or "(no prior conversation)"
     )
 
-    invoke_config = {"callbacks": [callback_handler]} if callback_handler else {}
+    invoke_config = {}
+    if callback_handler:
+        invoke_config = {
+            "callbacks": [callback_handler],
+            "metadata": {
+                "langfuse_session_id": session_id,
+                "langfuse_tags": ["final_answer"],
+                "run_name": "Final Answer",
+            },
+        }
     response = await llm.ainvoke(final_prompt, config=invoke_config)
     return response.content
 
@@ -244,10 +258,7 @@ async def chat(request: ChatRequest):
 
         answer_handler = None
         if langfuse is not None:
-            answer_handler = CallbackHandler(
-                trace_id=trace_id,
-                session_id=session.session_id,
-            )
+            answer_handler = CallbackHandler(trace_context={"trace_id": trace_id})
 
         try:
             kg_data = await query_mcp_knowledge_graph(
@@ -263,6 +274,7 @@ async def chat(request: ChatRequest):
                 kg_data=kg_data,
                 history=history,
                 callback_handler=answer_handler,
+                session_id=session.session_id,
             )
             source = "mcp_knowledge_graph"
 

--- a/src/topwr_api/server.py
+++ b/src/topwr_api/server.py
@@ -103,13 +103,16 @@ app.add_middleware(
 )
 
 
-async def query_mcp_knowledge_graph(user_input: str, trace_id: str = None) -> str:
+async def query_mcp_knowledge_graph(
+    user_input: str, trace_id: str = None, session_id: str = None
+) -> str:
     """
     Query the MCP server's knowledge graph tool.
 
     Args:
         user_input: User's question
         trace_id: Optional trace ID for tracking
+        session_id: Conversation session identifier from SessionManager
 
     Returns:
         Knowledge graph data as JSON string
@@ -120,6 +123,7 @@ async def query_mcp_knowledge_graph(user_input: str, trace_id: str = None) -> st
             {
                 "user_input": user_input,
                 "trace_id": trace_id,
+                "session_id": session_id,
             },
         )
         return "\n".join(item.text for item in result.content if hasattr(item, "text"))
@@ -211,6 +215,7 @@ async def chat(request: ChatRequest):
             kg_data = await query_mcp_knowledge_graph(
                 user_input=request.message,
                 trace_id=trace_id,
+                session_id=session.session_id,
             )
             logger.info(f"Retrieved knowledge graph data for session {session.session_id}")
 

--- a/src/topwr_api/server.py
+++ b/src/topwr_api/server.py
@@ -11,6 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastmcp import Client
 from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI
+from langfuse.langchain import CallbackHandler
 
 from ..config.config import get_config
 from .models import ChatRequest, ChatResponse, MessageRole
@@ -55,6 +56,28 @@ elif google_api_key:
 else:
     logger.warning("No LLM API key found. Chat will return raw knowledge graph data.")
 
+# Langfuse setup
+
+langfuse = None
+
+_langfuse_secret = os.getenv("LANGFUSE_SECRET_KEY")
+_langfuse_public = os.getenv("LANGFUSE_PUBLIC_KEY")
+_langfuse_host = os.getenv("LANGFUSE_HOST")
+
+if _langfuse_secret and _langfuse_public:
+    try:
+        from langfuse import Langfuse
+
+        langfuse = Langfuse(
+            secret_key=_langfuse_secret,
+            public_key=_langfuse_public,
+            host=_langfuse_host,
+        )
+    except Exception as e:
+        logger.warning(f"Warning: Failed to initialize Langfuse: {e}")
+else:
+    logger.info("Langfuse credentials not configured. Tracing disabled.")
+
 # Global session manager
 session_manager: SessionManager = None
 
@@ -76,6 +99,9 @@ async def lifespan(app: FastAPI):
     logger.info("Shutting down ToPWR API service...")
     stats = session_manager.get_stats()
     logger.info(f"Final stats: {stats}")
+
+    if langfuse:
+        langfuse.flush()
 
 
 # Initialize FastAPI app
@@ -129,7 +155,9 @@ async def query_mcp_knowledge_graph(
         return "\n".join(item.text for item in result.content if hasattr(item, "text"))
 
 
-async def generate_final_answer(user_input: str, kg_data: str, history: str = "") -> str:
+async def generate_final_answer(
+    user_input: str, kg_data: str, history: str = "", callback_handler=None
+) -> str:
     """
     Generate a final answer using the LLM with knowledge graph context.
 
@@ -137,6 +165,7 @@ async def generate_final_answer(user_input: str, kg_data: str, history: str = ""
         user_input: Original user question
         kg_data: Knowledge graph data from MCP server
         history: Recent conversation history as a formatted string
+        callback_handler: Optional Langfuse CallbackHandler
 
     Returns:
         LLM-generated answer
@@ -148,7 +177,8 @@ async def generate_final_answer(user_input: str, kg_data: str, history: str = ""
         user_input=user_input, data=kg_data, history=history or "(no prior conversation)"
     )
 
-    response = await llm.ainvoke(final_prompt)
+    invoke_config = {"callbacks": [callback_handler]} if callback_handler else {}
+    response = await llm.ainvoke(final_prompt, config=invoke_config)
     return response.content
 
 
@@ -211,6 +241,14 @@ async def chat(request: ChatRequest):
 
         # Query MCP knowledge graph
         trace_id = str(uuid.uuid4().hex)
+
+        answer_handler = None
+        if langfuse is not None:
+            answer_handler = CallbackHandler(
+                trace_id=trace_id,
+                session_id=session.session_id,
+            )
+
         try:
             kg_data = await query_mcp_knowledge_graph(
                 user_input=request.message,
@@ -224,6 +262,7 @@ async def chat(request: ChatRequest):
                 user_input=request.message,
                 kg_data=kg_data,
                 history=history,
+                callback_handler=answer_handler,
             )
             source = "mcp_knowledge_graph"
 


### PR DESCRIPTION
Langfuse was wired up but the data was useless — one global CallbackHandler meant every request wrote into the same trace, concurrent requests overwrote each other's handler on the RAG object, and the final-answer LLM call wasn't traced at all.

What changed:

- trace_id is generated per request in the ToPWR API and passed down to the MCP server
- handler is created per request and travels through LangGraph state instead of self.handler, so parallel requests can't mix traces
- moved handler setup to the Langfuse v3 API (trace_context — the old constructor kwargs crash on v3)
- final answer call is traced under the same trace_id, so one user request = one trace: Guardrails → Generate Cypher + Final Answer
- real session_id is propagated end to end (was: trace_id reused as session), so conversations group correctly in the Sessions view
- both servers flush Langfuse on shutdown (lifespan / atexit)