### PR TITLE
fix: make Text2Cypher retrieval case and diacritic insensitive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,10 +306,23 @@ async with self.driver.session() as session:
 ```
 
 ### Cypher Generation (Data Pipeline)
-LLM generates Cypher INSERT statements separated by `|` (pipe character). Strict rules enforced via prompt:
+LLM generates Cypher INSERT statements separated by `|` (pipe character). Strict rules are
+enforced via prompt and string values are folded deterministically before execution:
 - Unique variable names per statement
 - Polish characters normalized (ó→o, ę→e, etc.)
 - Token limit: 65536 to avoid DeepSeek API errors
+
+### Text2Cypher Search Normalization
+
+- The Cypher prompt receives both the original Polish question and a lowercase,
+  diacritic-folded search form.
+- Generated Cypher string literals are diacritic-folded again before validation and execution.
+  Case-insensitive human-readable matching uses `toLower(...)` on both sides, while stable IDs
+  retain their original case.
+- Labels, relationship types, property keys, and Cypher clauses are never normalized; they must
+  be copied exactly from the live Neo4j schema.
+- Read-only guardrails remain authoritative after normalization. In particular, `CALL` is still
+  blocked unless a separately reviewed procedure allowlist is introduced.
 
 ### Concurrent Pipeline Idempotency
 The data pipeline processes pages in batches with configurable concurrency and hash-based idempotency:

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,61 @@
+# Text2Cypher normalization benchmark
+
+This benchmark measures retrieval behavior for 28 Polish questions built from seven real PWr
+faculty names published at <https://pwr.edu.pl/wydzialy>. Each entity is queried in four buckets:
+
+- `canonical`: stored ASCII spelling and casing
+- `diacritics`: original Polish diacritics with stored casing
+- `case`: stored ASCII spelling in lowercase
+- `case_and_diacritics`: lowercase original Polish spelling
+
+Run all modes against the same Neo4j graph and the same deterministic accurate model:
+
+- `baseline`: `main` prompt and retrieval behavior
+- `prompt-only`: PR prompt, without deterministic query-literal folding
+- `full`: complete PR behavior
+
+The runner records correct-entity hit rate, relevant non-empty rate, and whether generated Cypher
+uses `toLower(...)` at least twice. The fixture is intentionally small and controlled; production
+graph validation still requires the team's graph dump or access to its Neo4j instance.
+
+The controlled graph can be reproduced with `seed_text2cypher_normalization.py`. The seeder sends
+the fixture through the selected revision's real `cypher_insert` prompt, converts its documented
+pipe-separated output into one executable Cypher query, and records the generated nodes and query.
+
+Both scripts accept `--provider openai` (the default production path) or `--provider clarin` (the
+repository's Polish-language fallback). Use one provider consistently for seeding and every run,
+and record the choice in the result report.
+
+`run_retrieval_normalization_matrix.py` is a provider-independent isolation test. It deliberately
+creates the kind of case-sensitive fuzzy query called out in review and executes 28 variants on a
+real Neo4j instance, first with diacritic folding only and then with the complete deterministic
+rewrite. This proves the normalization layer independently of prompt compliance; it does not
+replace the LLM-in-the-loop run above.
+
+Run the isolation matrix twice against the same local Neo4j instance:
+
+```powershell
+uv run python -m benchmarks.run_retrieval_normalization_matrix `
+  --cases benchmarks/text2cypher_normalization_entities.json `
+  --output benchmarks/results/diacritic-only.json `
+  --mode diacritic-only `
+  --neo4j-password '<password>'
+
+uv run python -m benchmarks.run_retrieval_normalization_matrix `
+  --cases benchmarks/text2cypher_normalization_entities.json `
+  --output benchmarks/results/full.json `
+  --mode full `
+  --neo4j-password '<password>'
+```
+
+See `RESULTS.md` for the checked-in comparison table and limitations.
+
+Example:
+
+```powershell
+uv run python benchmarks/run_text2cypher_normalization.py `
+  --repo-root C:\path\to\ml-mcp `
+  --cases benchmarks/text2cypher_normalization_entities.json `
+  --output benchmarks/results/full.json `
+  --mode full
+```

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -1,0 +1,44 @@
+# Text2Cypher normalization benchmark results
+
+Run date: 2026-08-17
+
+## Deterministic retrieval isolation
+
+The test graph contains seven real faculty names from the official PWr faculty list. The stored
+`title` values follow the ingestion contract and contain ASCII text without Polish diacritics. Each
+entity is queried in four forms, producing 28 total cases on the same Neo4j 5.18 instance.
+
+The generated test query intentionally omits `toLower(...)`. This isolates whether retrieval is
+deterministically safe when the LLM does not follow the prompt's case-insensitive matching rule.
+
+| Query bucket | Cases | Diacritic folding only | Full deterministic rewrite |
+|---|---:|---:|---:|
+| Canonical stored spelling | 7 | 7/7 (100%) | 7/7 (100%) |
+| Polish diacritics | 7 | 7/7 (100%) | 7/7 (100%) |
+| Lowercase ASCII | 7 | 0/7 (0%) | 7/7 (100%) |
+| Lowercase with Polish diacritics | 7 | 0/7 (0%) | 7/7 (100%) |
+| **Overall correct-entity hit rate** | **28** | **14/28 (50%)** | **28/28 (100%)** |
+| **Overall relevant non-empty rate** | **28** | **14/28 (50%)** | **28/28 (100%)** |
+| **Queries with `toLower` on both sides** | **28** | **0/28 (0%)** | **28/28 (100%)** |
+
+The full rewrite folds Polish diacritics in comparison literals and guarantees case-insensitive
+matching for `CONTAINS`, `STARTS WITH`, and `ENDS WITH`. Exact equality is not rewritten because the
+retrieval prompt reserves it for stable IDs, whose case may be significant.
+
+Raw rows and executed Cypher are recorded in `results/diacritic-only.json` and `results/full.json`.
+
+## LLM-in-the-loop benchmark
+
+`run_text2cypher_normalization.py` and `seed_text2cypher_normalization.py` provide the requested
+main vs prompt-only vs full benchmark using the repository's real ingestion and Text2Cypher
+prompts. Running it still requires valid OpenAI or CLARIN credentials and, for production-level
+evidence, the team's graph dump or Neo4j access. The deterministic result above does not claim to
+measure model prompt compliance.
+
+## Display-value follow-up
+
+The existing ingestion contract stores ASCII-folded values in place, so returned values are also
+ASCII-folded. This PR keeps that contract and focuses on retrieval correctness. Preserving Polish
+display text should be a separate schema/data migration: retain the original value for responses,
+write a parallel normalized property such as `title_norm` for matching, re-ingest existing data,
+and update retrieval to search the normalized property while returning the original one.

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Repeatable benchmark tooling for the knowledge-graph pipeline."""

--- a/benchmarks/fixtures/pwr_faculties.txt
+++ b/benchmarks/fixtures/pwr_faculties.txt
@@ -1,0 +1,13 @@
+Źródło: https://pwr.edu.pl/wydzialy
+
+Politechnika Wrocławska obejmuje między innymi następujące wydziały:
+
+- Wydział Budownictwa Lądowego i Wodnego
+- Wydział Informatyki i Telekomunikacji
+- Wydział Geoinżynierii, Górnictwa i Geologii
+- Wydział Inżynierii Środowiska
+- Wydział Zarządzania
+- Wydział Mechaniczno-Energetyczny
+- Wydział Elektroniki, Fotoniki i Mikrosystemów
+
+Każda wymieniona jednostka jest wydziałem Politechniki Wrocławskiej.

--- a/benchmarks/results/diacritic-only.json
+++ b/benchmarks/results/diacritic-only.json
@@ -1,0 +1,503 @@
+{
+  "mode": "diacritic-only",
+  "query_source": "deterministic template (LLM-independent normalization isolation)",
+  "source": "https://pwr.edu.pl/wydzialy",
+  "case_count": 28,
+  "summary": {
+    "canonical": {
+      "total": 7,
+      "hits": 7,
+      "hit_rate": 1.0,
+      "non_empty": 7,
+      "non_empty_rate": 1.0,
+      "tolower_compliant": 0,
+      "tolower_compliance_rate": 0.0
+    },
+    "overall": {
+      "total": 28,
+      "hits": 14,
+      "hit_rate": 0.5,
+      "non_empty": 14,
+      "non_empty_rate": 0.5,
+      "tolower_compliant": 0,
+      "tolower_compliance_rate": 0.0
+    },
+    "diacritics": {
+      "total": 7,
+      "hits": 7,
+      "hit_rate": 1.0,
+      "non_empty": 7,
+      "non_empty_rate": 1.0,
+      "tolower_compliant": 0,
+      "tolower_compliance_rate": 0.0
+    },
+    "case": {
+      "total": 7,
+      "hits": 0,
+      "hit_rate": 0.0,
+      "non_empty": 0,
+      "non_empty_rate": 0.0,
+      "tolower_compliant": 0,
+      "tolower_compliance_rate": 0.0
+    },
+    "case_and_diacritics": {
+      "total": 7,
+      "hits": 0,
+      "hit_rate": 0.0,
+      "non_empty": 0,
+      "non_empty_rate": 0.0,
+      "tolower_compliant": 0,
+      "tolower_compliance_rate": 0.0
+    }
+  },
+  "rows": [
+    {
+      "id": "civil-engineering:canonical",
+      "entity_id": "civil-engineering",
+      "category": "canonical",
+      "question": "Pokaż informacje o jednostce \"Wydzial Budownictwa Ladowego i Wodnego\".",
+      "search_value": "Wydzial Budownictwa Ladowego i Wodnego",
+      "expected": "Wydzial Budownictwa Ladowego i Wodnego",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'Wydzial Budownictwa Ladowego i Wodnego' RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Budownictwa Ladowego i Wodnego"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "civil-engineering:diacritics",
+      "entity_id": "civil-engineering",
+      "category": "diacritics",
+      "question": "Pokaż informacje o jednostce \"Wydział Budownictwa Lądowego i Wodnego\".",
+      "search_value": "Wydział Budownictwa Lądowego i Wodnego",
+      "expected": "Wydzial Budownictwa Ladowego i Wodnego",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'Wydzial Budownictwa Ladowego i Wodnego' RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Budownictwa Ladowego i Wodnego"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "civil-engineering:case",
+      "entity_id": "civil-engineering",
+      "category": "case",
+      "question": "Pokaż informacje o jednostce \"wydzial budownictwa ladowego i wodnego\".",
+      "search_value": "wydzial budownictwa ladowego i wodnego",
+      "expected": "Wydzial Budownictwa Ladowego i Wodnego",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'wydzial budownictwa ladowego i wodnego' RETURN n.title AS title LIMIT 10",
+      "context": [],
+      "hit": false,
+      "non_empty": false,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "civil-engineering:case_and_diacritics",
+      "entity_id": "civil-engineering",
+      "category": "case_and_diacritics",
+      "question": "Pokaż informacje o jednostce \"wydział budownictwa lądowego i wodnego\".",
+      "search_value": "wydział budownictwa lądowego i wodnego",
+      "expected": "Wydzial Budownictwa Ladowego i Wodnego",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'wydzial budownictwa ladowego i wodnego' RETURN n.title AS title LIMIT 10",
+      "context": [],
+      "hit": false,
+      "non_empty": false,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "computer-science:canonical",
+      "entity_id": "computer-science",
+      "category": "canonical",
+      "question": "Pokaż informacje o jednostce \"Wydzial Informatyki i Telekomunikacji\".",
+      "search_value": "Wydzial Informatyki i Telekomunikacji",
+      "expected": "Wydzial Informatyki i Telekomunikacji",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'Wydzial Informatyki i Telekomunikacji' RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Informatyki i Telekomunikacji"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "computer-science:diacritics",
+      "entity_id": "computer-science",
+      "category": "diacritics",
+      "question": "Pokaż informacje o jednostce \"Wydział Informatyki i Telekomunikacji\".",
+      "search_value": "Wydział Informatyki i Telekomunikacji",
+      "expected": "Wydzial Informatyki i Telekomunikacji",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'Wydzial Informatyki i Telekomunikacji' RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Informatyki i Telekomunikacji"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "computer-science:case",
+      "entity_id": "computer-science",
+      "category": "case",
+      "question": "Pokaż informacje o jednostce \"wydzial informatyki i telekomunikacji\".",
+      "search_value": "wydzial informatyki i telekomunikacji",
+      "expected": "Wydzial Informatyki i Telekomunikacji",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'wydzial informatyki i telekomunikacji' RETURN n.title AS title LIMIT 10",
+      "context": [],
+      "hit": false,
+      "non_empty": false,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "computer-science:case_and_diacritics",
+      "entity_id": "computer-science",
+      "category": "case_and_diacritics",
+      "question": "Pokaż informacje o jednostce \"wydział informatyki i telekomunikacji\".",
+      "search_value": "wydział informatyki i telekomunikacji",
+      "expected": "Wydzial Informatyki i Telekomunikacji",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'wydzial informatyki i telekomunikacji' RETURN n.title AS title LIMIT 10",
+      "context": [],
+      "hit": false,
+      "non_empty": false,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "geoengineering:canonical",
+      "entity_id": "geoengineering",
+      "category": "canonical",
+      "question": "Pokaż informacje o jednostce \"Wydzial Geoinzynierii, Gornictwa i Geologii\".",
+      "search_value": "Wydzial Geoinzynierii, Gornictwa i Geologii",
+      "expected": "Wydzial Geoinzynierii, Gornictwa i Geologii",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'Wydzial Geoinzynierii, Gornictwa i Geologii' RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Geoinzynierii, Gornictwa i Geologii"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "geoengineering:diacritics",
+      "entity_id": "geoengineering",
+      "category": "diacritics",
+      "question": "Pokaż informacje o jednostce \"Wydział Geoinżynierii, Górnictwa i Geologii\".",
+      "search_value": "Wydział Geoinżynierii, Górnictwa i Geologii",
+      "expected": "Wydzial Geoinzynierii, Gornictwa i Geologii",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'Wydzial Geoinzynierii, Gornictwa i Geologii' RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Geoinzynierii, Gornictwa i Geologii"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "geoengineering:case",
+      "entity_id": "geoengineering",
+      "category": "case",
+      "question": "Pokaż informacje o jednostce \"wydzial geoinzynierii, gornictwa i geologii\".",
+      "search_value": "wydzial geoinzynierii, gornictwa i geologii",
+      "expected": "Wydzial Geoinzynierii, Gornictwa i Geologii",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'wydzial geoinzynierii, gornictwa i geologii' RETURN n.title AS title LIMIT 10",
+      "context": [],
+      "hit": false,
+      "non_empty": false,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "geoengineering:case_and_diacritics",
+      "entity_id": "geoengineering",
+      "category": "case_and_diacritics",
+      "question": "Pokaż informacje o jednostce \"wydział geoinżynierii, górnictwa i geologii\".",
+      "search_value": "wydział geoinżynierii, górnictwa i geologii",
+      "expected": "Wydzial Geoinzynierii, Gornictwa i Geologii",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'wydzial geoinzynierii, gornictwa i geologii' RETURN n.title AS title LIMIT 10",
+      "context": [],
+      "hit": false,
+      "non_empty": false,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "environmental-engineering:canonical",
+      "entity_id": "environmental-engineering",
+      "category": "canonical",
+      "question": "Pokaż informacje o jednostce \"Wydzial Inzynierii Srodowiska\".",
+      "search_value": "Wydzial Inzynierii Srodowiska",
+      "expected": "Wydzial Inzynierii Srodowiska",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'Wydzial Inzynierii Srodowiska' RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Inzynierii Srodowiska"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "environmental-engineering:diacritics",
+      "entity_id": "environmental-engineering",
+      "category": "diacritics",
+      "question": "Pokaż informacje o jednostce \"Wydział Inżynierii Środowiska\".",
+      "search_value": "Wydział Inżynierii Środowiska",
+      "expected": "Wydzial Inzynierii Srodowiska",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'Wydzial Inzynierii Srodowiska' RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Inzynierii Srodowiska"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "environmental-engineering:case",
+      "entity_id": "environmental-engineering",
+      "category": "case",
+      "question": "Pokaż informacje o jednostce \"wydzial inzynierii srodowiska\".",
+      "search_value": "wydzial inzynierii srodowiska",
+      "expected": "Wydzial Inzynierii Srodowiska",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'wydzial inzynierii srodowiska' RETURN n.title AS title LIMIT 10",
+      "context": [],
+      "hit": false,
+      "non_empty": false,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "environmental-engineering:case_and_diacritics",
+      "entity_id": "environmental-engineering",
+      "category": "case_and_diacritics",
+      "question": "Pokaż informacje o jednostce \"wydział inżynierii środowiska\".",
+      "search_value": "wydział inżynierii środowiska",
+      "expected": "Wydzial Inzynierii Srodowiska",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'wydzial inzynierii srodowiska' RETURN n.title AS title LIMIT 10",
+      "context": [],
+      "hit": false,
+      "non_empty": false,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "management:canonical",
+      "entity_id": "management",
+      "category": "canonical",
+      "question": "Pokaż informacje o jednostce \"Wydzial Zarzadzania\".",
+      "search_value": "Wydzial Zarzadzania",
+      "expected": "Wydzial Zarzadzania",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'Wydzial Zarzadzania' RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Zarzadzania"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "management:diacritics",
+      "entity_id": "management",
+      "category": "diacritics",
+      "question": "Pokaż informacje o jednostce \"Wydział Zarządzania\".",
+      "search_value": "Wydział Zarządzania",
+      "expected": "Wydzial Zarzadzania",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'Wydzial Zarzadzania' RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Zarzadzania"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "management:case",
+      "entity_id": "management",
+      "category": "case",
+      "question": "Pokaż informacje o jednostce \"wydzial zarzadzania\".",
+      "search_value": "wydzial zarzadzania",
+      "expected": "Wydzial Zarzadzania",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'wydzial zarzadzania' RETURN n.title AS title LIMIT 10",
+      "context": [],
+      "hit": false,
+      "non_empty": false,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "management:case_and_diacritics",
+      "entity_id": "management",
+      "category": "case_and_diacritics",
+      "question": "Pokaż informacje o jednostce \"wydział zarządzania\".",
+      "search_value": "wydział zarządzania",
+      "expected": "Wydzial Zarzadzania",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'wydzial zarzadzania' RETURN n.title AS title LIMIT 10",
+      "context": [],
+      "hit": false,
+      "non_empty": false,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "mechanical-energy:canonical",
+      "entity_id": "mechanical-energy",
+      "category": "canonical",
+      "question": "Pokaż informacje o jednostce \"Wydzial Mechaniczno-Energetyczny\".",
+      "search_value": "Wydzial Mechaniczno-Energetyczny",
+      "expected": "Wydzial Mechaniczno-Energetyczny",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'Wydzial Mechaniczno-Energetyczny' RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Mechaniczno-Energetyczny"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "mechanical-energy:diacritics",
+      "entity_id": "mechanical-energy",
+      "category": "diacritics",
+      "question": "Pokaż informacje o jednostce \"Wydział Mechaniczno-Energetyczny\".",
+      "search_value": "Wydział Mechaniczno-Energetyczny",
+      "expected": "Wydzial Mechaniczno-Energetyczny",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'Wydzial Mechaniczno-Energetyczny' RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Mechaniczno-Energetyczny"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "mechanical-energy:case",
+      "entity_id": "mechanical-energy",
+      "category": "case",
+      "question": "Pokaż informacje o jednostce \"wydzial mechaniczno-energetyczny\".",
+      "search_value": "wydzial mechaniczno-energetyczny",
+      "expected": "Wydzial Mechaniczno-Energetyczny",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'wydzial mechaniczno-energetyczny' RETURN n.title AS title LIMIT 10",
+      "context": [],
+      "hit": false,
+      "non_empty": false,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "mechanical-energy:case_and_diacritics",
+      "entity_id": "mechanical-energy",
+      "category": "case_and_diacritics",
+      "question": "Pokaż informacje o jednostce \"wydział mechaniczno-energetyczny\".",
+      "search_value": "wydział mechaniczno-energetyczny",
+      "expected": "Wydzial Mechaniczno-Energetyczny",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'wydzial mechaniczno-energetyczny' RETURN n.title AS title LIMIT 10",
+      "context": [],
+      "hit": false,
+      "non_empty": false,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "electronics-photonics:canonical",
+      "entity_id": "electronics-photonics",
+      "category": "canonical",
+      "question": "Pokaż informacje o jednostce \"Wydzial Elektroniki, Fotoniki i Mikrosystemow\".",
+      "search_value": "Wydzial Elektroniki, Fotoniki i Mikrosystemow",
+      "expected": "Wydzial Elektroniki, Fotoniki i Mikrosystemow",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'Wydzial Elektroniki, Fotoniki i Mikrosystemow' RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Elektroniki, Fotoniki i Mikrosystemow"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "electronics-photonics:diacritics",
+      "entity_id": "electronics-photonics",
+      "category": "diacritics",
+      "question": "Pokaż informacje o jednostce \"Wydział Elektroniki, Fotoniki i Mikrosystemów\".",
+      "search_value": "Wydział Elektroniki, Fotoniki i Mikrosystemów",
+      "expected": "Wydzial Elektroniki, Fotoniki i Mikrosystemow",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'Wydzial Elektroniki, Fotoniki i Mikrosystemow' RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Elektroniki, Fotoniki i Mikrosystemow"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "electronics-photonics:case",
+      "entity_id": "electronics-photonics",
+      "category": "case",
+      "question": "Pokaż informacje o jednostce \"wydzial elektroniki, fotoniki i mikrosystemow\".",
+      "search_value": "wydzial elektroniki, fotoniki i mikrosystemow",
+      "expected": "Wydzial Elektroniki, Fotoniki i Mikrosystemow",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'wydzial elektroniki, fotoniki i mikrosystemow' RETURN n.title AS title LIMIT 10",
+      "context": [],
+      "hit": false,
+      "non_empty": false,
+      "tolower_compliant": false,
+      "error": null
+    },
+    {
+      "id": "electronics-photonics:case_and_diacritics",
+      "entity_id": "electronics-photonics",
+      "category": "case_and_diacritics",
+      "question": "Pokaż informacje o jednostce \"wydział elektroniki, fotoniki i mikrosystemów\".",
+      "search_value": "wydział elektroniki, fotoniki i mikrosystemów",
+      "expected": "Wydzial Elektroniki, Fotoniki i Mikrosystemow",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE n.title CONTAINS 'wydzial elektroniki, fotoniki i mikrosystemow' RETURN n.title AS title LIMIT 10",
+      "context": [],
+      "hit": false,
+      "non_empty": false,
+      "tolower_compliant": false,
+      "error": null
+    }
+  ]
+}

--- a/benchmarks/results/full.json
+++ b/benchmarks/results/full.json
@@ -1,0 +1,559 @@
+{
+  "mode": "full",
+  "query_source": "deterministic template (LLM-independent normalization isolation)",
+  "source": "https://pwr.edu.pl/wydzialy",
+  "case_count": 28,
+  "summary": {
+    "canonical": {
+      "total": 7,
+      "hits": 7,
+      "hit_rate": 1.0,
+      "non_empty": 7,
+      "non_empty_rate": 1.0,
+      "tolower_compliant": 7,
+      "tolower_compliance_rate": 1.0
+    },
+    "overall": {
+      "total": 28,
+      "hits": 28,
+      "hit_rate": 1.0,
+      "non_empty": 28,
+      "non_empty_rate": 1.0,
+      "tolower_compliant": 28,
+      "tolower_compliance_rate": 1.0
+    },
+    "diacritics": {
+      "total": 7,
+      "hits": 7,
+      "hit_rate": 1.0,
+      "non_empty": 7,
+      "non_empty_rate": 1.0,
+      "tolower_compliant": 7,
+      "tolower_compliance_rate": 1.0
+    },
+    "case": {
+      "total": 7,
+      "hits": 7,
+      "hit_rate": 1.0,
+      "non_empty": 7,
+      "non_empty_rate": 1.0,
+      "tolower_compliant": 7,
+      "tolower_compliance_rate": 1.0
+    },
+    "case_and_diacritics": {
+      "total": 7,
+      "hits": 7,
+      "hit_rate": 1.0,
+      "non_empty": 7,
+      "non_empty_rate": 1.0,
+      "tolower_compliant": 7,
+      "tolower_compliance_rate": 1.0
+    }
+  },
+  "rows": [
+    {
+      "id": "civil-engineering:canonical",
+      "entity_id": "civil-engineering",
+      "category": "canonical",
+      "question": "Pokaż informacje o jednostce \"Wydzial Budownictwa Ladowego i Wodnego\".",
+      "search_value": "Wydzial Budownictwa Ladowego i Wodnego",
+      "expected": "Wydzial Budownictwa Ladowego i Wodnego",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('Wydzial Budownictwa Ladowego i Wodnego') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Budownictwa Ladowego i Wodnego"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "civil-engineering:diacritics",
+      "entity_id": "civil-engineering",
+      "category": "diacritics",
+      "question": "Pokaż informacje o jednostce \"Wydział Budownictwa Lądowego i Wodnego\".",
+      "search_value": "Wydział Budownictwa Lądowego i Wodnego",
+      "expected": "Wydzial Budownictwa Ladowego i Wodnego",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('Wydzial Budownictwa Ladowego i Wodnego') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Budownictwa Ladowego i Wodnego"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "civil-engineering:case",
+      "entity_id": "civil-engineering",
+      "category": "case",
+      "question": "Pokaż informacje o jednostce \"wydzial budownictwa ladowego i wodnego\".",
+      "search_value": "wydzial budownictwa ladowego i wodnego",
+      "expected": "Wydzial Budownictwa Ladowego i Wodnego",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('wydzial budownictwa ladowego i wodnego') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Budownictwa Ladowego i Wodnego"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "civil-engineering:case_and_diacritics",
+      "entity_id": "civil-engineering",
+      "category": "case_and_diacritics",
+      "question": "Pokaż informacje o jednostce \"wydział budownictwa lądowego i wodnego\".",
+      "search_value": "wydział budownictwa lądowego i wodnego",
+      "expected": "Wydzial Budownictwa Ladowego i Wodnego",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('wydzial budownictwa ladowego i wodnego') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Budownictwa Ladowego i Wodnego"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "computer-science:canonical",
+      "entity_id": "computer-science",
+      "category": "canonical",
+      "question": "Pokaż informacje o jednostce \"Wydzial Informatyki i Telekomunikacji\".",
+      "search_value": "Wydzial Informatyki i Telekomunikacji",
+      "expected": "Wydzial Informatyki i Telekomunikacji",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('Wydzial Informatyki i Telekomunikacji') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Informatyki i Telekomunikacji"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "computer-science:diacritics",
+      "entity_id": "computer-science",
+      "category": "diacritics",
+      "question": "Pokaż informacje o jednostce \"Wydział Informatyki i Telekomunikacji\".",
+      "search_value": "Wydział Informatyki i Telekomunikacji",
+      "expected": "Wydzial Informatyki i Telekomunikacji",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('Wydzial Informatyki i Telekomunikacji') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Informatyki i Telekomunikacji"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "computer-science:case",
+      "entity_id": "computer-science",
+      "category": "case",
+      "question": "Pokaż informacje o jednostce \"wydzial informatyki i telekomunikacji\".",
+      "search_value": "wydzial informatyki i telekomunikacji",
+      "expected": "Wydzial Informatyki i Telekomunikacji",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('wydzial informatyki i telekomunikacji') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Informatyki i Telekomunikacji"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "computer-science:case_and_diacritics",
+      "entity_id": "computer-science",
+      "category": "case_and_diacritics",
+      "question": "Pokaż informacje o jednostce \"wydział informatyki i telekomunikacji\".",
+      "search_value": "wydział informatyki i telekomunikacji",
+      "expected": "Wydzial Informatyki i Telekomunikacji",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('wydzial informatyki i telekomunikacji') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Informatyki i Telekomunikacji"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "geoengineering:canonical",
+      "entity_id": "geoengineering",
+      "category": "canonical",
+      "question": "Pokaż informacje o jednostce \"Wydzial Geoinzynierii, Gornictwa i Geologii\".",
+      "search_value": "Wydzial Geoinzynierii, Gornictwa i Geologii",
+      "expected": "Wydzial Geoinzynierii, Gornictwa i Geologii",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('Wydzial Geoinzynierii, Gornictwa i Geologii') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Geoinzynierii, Gornictwa i Geologii"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "geoengineering:diacritics",
+      "entity_id": "geoengineering",
+      "category": "diacritics",
+      "question": "Pokaż informacje o jednostce \"Wydział Geoinżynierii, Górnictwa i Geologii\".",
+      "search_value": "Wydział Geoinżynierii, Górnictwa i Geologii",
+      "expected": "Wydzial Geoinzynierii, Gornictwa i Geologii",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('Wydzial Geoinzynierii, Gornictwa i Geologii') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Geoinzynierii, Gornictwa i Geologii"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "geoengineering:case",
+      "entity_id": "geoengineering",
+      "category": "case",
+      "question": "Pokaż informacje o jednostce \"wydzial geoinzynierii, gornictwa i geologii\".",
+      "search_value": "wydzial geoinzynierii, gornictwa i geologii",
+      "expected": "Wydzial Geoinzynierii, Gornictwa i Geologii",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('wydzial geoinzynierii, gornictwa i geologii') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Geoinzynierii, Gornictwa i Geologii"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "geoengineering:case_and_diacritics",
+      "entity_id": "geoengineering",
+      "category": "case_and_diacritics",
+      "question": "Pokaż informacje o jednostce \"wydział geoinżynierii, górnictwa i geologii\".",
+      "search_value": "wydział geoinżynierii, górnictwa i geologii",
+      "expected": "Wydzial Geoinzynierii, Gornictwa i Geologii",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('wydzial geoinzynierii, gornictwa i geologii') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Geoinzynierii, Gornictwa i Geologii"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "environmental-engineering:canonical",
+      "entity_id": "environmental-engineering",
+      "category": "canonical",
+      "question": "Pokaż informacje o jednostce \"Wydzial Inzynierii Srodowiska\".",
+      "search_value": "Wydzial Inzynierii Srodowiska",
+      "expected": "Wydzial Inzynierii Srodowiska",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('Wydzial Inzynierii Srodowiska') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Inzynierii Srodowiska"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "environmental-engineering:diacritics",
+      "entity_id": "environmental-engineering",
+      "category": "diacritics",
+      "question": "Pokaż informacje o jednostce \"Wydział Inżynierii Środowiska\".",
+      "search_value": "Wydział Inżynierii Środowiska",
+      "expected": "Wydzial Inzynierii Srodowiska",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('Wydzial Inzynierii Srodowiska') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Inzynierii Srodowiska"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "environmental-engineering:case",
+      "entity_id": "environmental-engineering",
+      "category": "case",
+      "question": "Pokaż informacje o jednostce \"wydzial inzynierii srodowiska\".",
+      "search_value": "wydzial inzynierii srodowiska",
+      "expected": "Wydzial Inzynierii Srodowiska",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('wydzial inzynierii srodowiska') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Inzynierii Srodowiska"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "environmental-engineering:case_and_diacritics",
+      "entity_id": "environmental-engineering",
+      "category": "case_and_diacritics",
+      "question": "Pokaż informacje o jednostce \"wydział inżynierii środowiska\".",
+      "search_value": "wydział inżynierii środowiska",
+      "expected": "Wydzial Inzynierii Srodowiska",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('wydzial inzynierii srodowiska') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Inzynierii Srodowiska"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "management:canonical",
+      "entity_id": "management",
+      "category": "canonical",
+      "question": "Pokaż informacje o jednostce \"Wydzial Zarzadzania\".",
+      "search_value": "Wydzial Zarzadzania",
+      "expected": "Wydzial Zarzadzania",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('Wydzial Zarzadzania') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Zarzadzania"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "management:diacritics",
+      "entity_id": "management",
+      "category": "diacritics",
+      "question": "Pokaż informacje o jednostce \"Wydział Zarządzania\".",
+      "search_value": "Wydział Zarządzania",
+      "expected": "Wydzial Zarzadzania",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('Wydzial Zarzadzania') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Zarzadzania"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "management:case",
+      "entity_id": "management",
+      "category": "case",
+      "question": "Pokaż informacje o jednostce \"wydzial zarzadzania\".",
+      "search_value": "wydzial zarzadzania",
+      "expected": "Wydzial Zarzadzania",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('wydzial zarzadzania') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Zarzadzania"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "management:case_and_diacritics",
+      "entity_id": "management",
+      "category": "case_and_diacritics",
+      "question": "Pokaż informacje o jednostce \"wydział zarządzania\".",
+      "search_value": "wydział zarządzania",
+      "expected": "Wydzial Zarzadzania",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('wydzial zarzadzania') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Zarzadzania"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "mechanical-energy:canonical",
+      "entity_id": "mechanical-energy",
+      "category": "canonical",
+      "question": "Pokaż informacje o jednostce \"Wydzial Mechaniczno-Energetyczny\".",
+      "search_value": "Wydzial Mechaniczno-Energetyczny",
+      "expected": "Wydzial Mechaniczno-Energetyczny",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('Wydzial Mechaniczno-Energetyczny') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Mechaniczno-Energetyczny"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "mechanical-energy:diacritics",
+      "entity_id": "mechanical-energy",
+      "category": "diacritics",
+      "question": "Pokaż informacje o jednostce \"Wydział Mechaniczno-Energetyczny\".",
+      "search_value": "Wydział Mechaniczno-Energetyczny",
+      "expected": "Wydzial Mechaniczno-Energetyczny",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('Wydzial Mechaniczno-Energetyczny') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Mechaniczno-Energetyczny"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "mechanical-energy:case",
+      "entity_id": "mechanical-energy",
+      "category": "case",
+      "question": "Pokaż informacje o jednostce \"wydzial mechaniczno-energetyczny\".",
+      "search_value": "wydzial mechaniczno-energetyczny",
+      "expected": "Wydzial Mechaniczno-Energetyczny",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('wydzial mechaniczno-energetyczny') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Mechaniczno-Energetyczny"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "mechanical-energy:case_and_diacritics",
+      "entity_id": "mechanical-energy",
+      "category": "case_and_diacritics",
+      "question": "Pokaż informacje o jednostce \"wydział mechaniczno-energetyczny\".",
+      "search_value": "wydział mechaniczno-energetyczny",
+      "expected": "Wydzial Mechaniczno-Energetyczny",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('wydzial mechaniczno-energetyczny') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Mechaniczno-Energetyczny"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "electronics-photonics:canonical",
+      "entity_id": "electronics-photonics",
+      "category": "canonical",
+      "question": "Pokaż informacje o jednostce \"Wydzial Elektroniki, Fotoniki i Mikrosystemow\".",
+      "search_value": "Wydzial Elektroniki, Fotoniki i Mikrosystemow",
+      "expected": "Wydzial Elektroniki, Fotoniki i Mikrosystemow",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('Wydzial Elektroniki, Fotoniki i Mikrosystemow') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Elektroniki, Fotoniki i Mikrosystemow"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "electronics-photonics:diacritics",
+      "entity_id": "electronics-photonics",
+      "category": "diacritics",
+      "question": "Pokaż informacje o jednostce \"Wydział Elektroniki, Fotoniki i Mikrosystemów\".",
+      "search_value": "Wydział Elektroniki, Fotoniki i Mikrosystemów",
+      "expected": "Wydzial Elektroniki, Fotoniki i Mikrosystemow",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('Wydzial Elektroniki, Fotoniki i Mikrosystemow') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Elektroniki, Fotoniki i Mikrosystemow"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "electronics-photonics:case",
+      "entity_id": "electronics-photonics",
+      "category": "case",
+      "question": "Pokaż informacje o jednostce \"wydzial elektroniki, fotoniki i mikrosystemow\".",
+      "search_value": "wydzial elektroniki, fotoniki i mikrosystemow",
+      "expected": "Wydzial Elektroniki, Fotoniki i Mikrosystemow",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('wydzial elektroniki, fotoniki i mikrosystemow') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Elektroniki, Fotoniki i Mikrosystemow"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    },
+    {
+      "id": "electronics-photonics:case_and_diacritics",
+      "entity_id": "electronics-photonics",
+      "category": "case_and_diacritics",
+      "question": "Pokaż informacje o jednostce \"wydział elektroniki, fotoniki i mikrosystemów\".",
+      "search_value": "wydział elektroniki, fotoniki i mikrosystemów",
+      "expected": "Wydzial Elektroniki, Fotoniki i Mikrosystemow",
+      "executed_cypher": "MATCH (n:Text2CypherNormalizationBenchmark) WHERE toLower(n.title) CONTAINS toLower('wydzial elektroniki, fotoniki i mikrosystemow') RETURN n.title AS title LIMIT 10",
+      "context": [
+        {
+          "title": "Wydzial Elektroniki, Fotoniki i Mikrosystemow"
+        }
+      ],
+      "hit": true,
+      "non_empty": true,
+      "tolower_compliant": true,
+      "error": null
+    }
+  ]
+}

--- a/benchmarks/run_retrieval_normalization_matrix.py
+++ b/benchmarks/run_retrieval_normalization_matrix.py
@@ -1,0 +1,110 @@
+"""Measure deterministic retrieval normalization against a real Neo4j instance."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from neo4j import GraphDatabase
+
+from benchmarks.run_text2cypher_normalization import load_cases, normalize_for_scoring, summarize
+from src.text_normalization import (
+    ensure_case_insensitive_fuzzy_matching,
+    fold_diacritics,
+    normalize_cypher_string_literals,
+)
+
+BENCHMARK_LABEL = "Text2CypherNormalizationBenchmark"
+
+
+def escape_cypher_literal(value: str) -> str:
+    """Escape a value for the controlled benchmark's single-quoted Cypher literal."""
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def build_query(search_value: str, mode: str) -> str:
+    """Build and normalize the deliberately case-sensitive generated query."""
+    query = (
+        f"MATCH (n:{BENCHMARK_LABEL}) "
+        f"WHERE n.title CONTAINS '{escape_cypher_literal(search_value)}' "
+        "RETURN n.title AS title"
+    )
+    query = normalize_cypher_string_literals(query, normalizer=fold_diacritics)
+    if mode == "full":
+        query = ensure_case_insensitive_fuzzy_matching(query)
+    return f"{query} LIMIT 10"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cases", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--mode", choices=("diacritic-only", "full"), required=True)
+    parser.add_argument("--neo4j-uri", default="bolt://localhost:17687")
+    parser.add_argument("--neo4j-user", default="neo4j")
+    parser.add_argument("--neo4j-password", required=True)
+    return parser.parse_args()
+
+
+def run_matrix(args: argparse.Namespace) -> dict[str, Any]:
+    """Seed seven entities and execute all 28 query variants on the same graph."""
+    payload = json.loads(args.cases.resolve().read_text(encoding="utf-8"))
+    source, cases = load_cases(args.cases.resolve())
+    entities = payload["entities"]
+
+    rows: list[dict[str, Any]] = []
+    with GraphDatabase.driver(
+        args.neo4j_uri,
+        auth=(args.neo4j_user, args.neo4j_password),
+    ) as driver:
+        driver.execute_query(
+            f"MATCH (n:{BENCHMARK_LABEL}) DETACH DELETE n",
+            database_="neo4j",
+        )
+        driver.execute_query(
+            f"UNWIND $entities AS entity CREATE (n:{BENCHMARK_LABEL}:Faculty {{"
+            "title: entity.stored, context: entity.original})",
+            entities=entities,
+            database_="neo4j",
+        )
+
+        for case in cases:
+            query = build_query(case["search_value"], args.mode)
+            records, _, _ = driver.execute_query(query, database_="neo4j")
+            context = [record.data() for record in records]
+            context_text = normalize_for_scoring(json.dumps(context, ensure_ascii=False))
+            expected_text = normalize_for_scoring(case["expected"])
+            rows.append(
+                {
+                    **case,
+                    "executed_cypher": query,
+                    "context": context,
+                    "hit": expected_text in context_text,
+                    "non_empty": bool(context),
+                    "tolower_compliant": query.lower().count("tolower(") >= 2,
+                    "error": None,
+                }
+            )
+
+    result = {
+        "mode": args.mode,
+        "query_source": "deterministic template (LLM-independent normalization isolation)",
+        "source": source,
+        "case_count": len(rows),
+        "summary": summarize(rows),
+        "rows": rows,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
+    return result
+
+
+def main() -> None:
+    result = run_matrix(parse_args())
+    print(json.dumps(result["summary"], indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/run_text2cypher_normalization.py
+++ b/benchmarks/run_text2cypher_normalization.py
@@ -1,0 +1,208 @@
+"""Run the Text2Cypher normalization benchmark against one code revision."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import unicodedata
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+
+POLISH_DIACRITIC_TRANSLATION = str.maketrans({"ł": "l", "Ł": "L"})
+VARIANT_BUILDERS = {
+    "canonical": lambda entity: entity["stored"],
+    "diacritics": lambda entity: entity["original"],
+    "case": lambda entity: entity["stored"].lower(),
+    "case_and_diacritics": lambda entity: entity["original"].lower(),
+}
+
+
+def normalize_for_scoring(value: str) -> str:
+    """Return a lowercase, diacritic-folded representation for result scoring."""
+    translated = value.translate(POLISH_DIACRITIC_TRANSLATION)
+    decomposed = unicodedata.normalize("NFKD", translated)
+    folded = "".join(char for char in decomposed if not unicodedata.combining(char))
+    return folded.casefold()
+
+
+def load_cases(path: Path) -> tuple[str, list[dict[str, str]]]:
+    """Expand entity definitions into the four requested variation buckets."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    template = payload["question_template"]
+    cases: list[dict[str, str]] = []
+
+    for entity in payload["entities"]:
+        for category, builder in VARIANT_BUILDERS.items():
+            rendered_entity = builder(entity)
+            cases.append(
+                {
+                    "id": f"{entity['id']}:{category}",
+                    "entity_id": entity["id"],
+                    "category": category,
+                    "question": template.format(entity=rendered_entity),
+                    "search_value": rendered_entity,
+                    "expected": entity["stored"],
+                }
+            )
+
+    return payload["source"], cases
+
+
+def summarize(rows: list[dict[str, Any]]) -> dict[str, dict[str, float | int]]:
+    """Aggregate hit, non-empty, and toLower compliance metrics by category."""
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        grouped[row["category"]].append(row)
+        grouped["overall"].append(row)
+
+    summary: dict[str, dict[str, float | int]] = {}
+    for category, category_rows in grouped.items():
+        total = len(category_rows)
+        summary[category] = {
+            "total": total,
+            "hits": sum(bool(row["hit"]) for row in category_rows),
+            "hit_rate": round(sum(bool(row["hit"]) for row in category_rows) / total, 4),
+            "non_empty": sum(bool(row["non_empty"]) for row in category_rows),
+            "non_empty_rate": round(
+                sum(bool(row["non_empty"]) for row in category_rows) / total,
+                4,
+            ),
+            "tolower_compliant": sum(bool(row["tolower_compliant"]) for row in category_rows),
+            "tolower_compliance_rate": round(
+                sum(bool(row["tolower_compliant"]) for row in category_rows) / total,
+                4,
+            ),
+        }
+    return summary
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--cases", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--mode", choices=("baseline", "prompt-only", "full"), required=True)
+    parser.add_argument("--env-file", type=Path, default=Path(".env"))
+    parser.add_argument("--neo4j-uri", default="bolt://localhost:17687")
+    parser.add_argument("--provider", choices=("openai", "clarin"), default="openai")
+    return parser.parse_args()
+
+
+def run_benchmark(args: argparse.Namespace) -> dict[str, Any]:
+    """Generate and execute Cypher for every case using the selected revision."""
+    repo_root = args.repo_root.resolve()
+    load_dotenv(args.env_file.resolve(), override=False)
+    os.environ["NEO4J_URI"] = args.neo4j_uri
+
+    sys.path.insert(0, str(repo_root))
+    os.chdir(repo_root)
+
+    from src.config.config import get_config
+    from src.mcp_server.tools.knowledge_graph.cypher_guardrails import (
+        ensure_limit,
+        strip_code_fences,
+        validate_read_only,
+    )
+    from src.mcp_server.tools.knowledge_graph.rag import RAG
+
+    config = get_config()
+    api_key = (
+        os.getenv("OPENAI_API_KEY")
+        or os.getenv("DEEPSEEK_API_KEY")
+        or os.getenv("GOOGLE_API_KEY")
+        or ""
+    )
+    rag = RAG(
+        api_key=api_key,
+        neo4j_url=args.neo4j_uri,
+        neo4j_username=os.environ["NEO4J_USER"],
+        neo4j_password=os.environ["NEO4J_PASSWORD"],
+        max_results=10,
+    )
+    model_name = config.llm.accurate_model.name
+    if args.provider == "clarin":
+        from langchain_openai import ChatOpenAI
+
+        model_name = config.llm.clarin.name
+        rag.cypher_llm = ChatOpenAI(
+            model_name=model_name,
+            base_url=config.llm.clarin.base_url,
+            api_key=os.environ["CLARIN_API_KEY"],
+            temperature=0,
+        )
+
+    source, cases = load_cases(args.cases)
+    rows: list[dict[str, Any]] = []
+    for index, case in enumerate(cases, start=1):
+        print(f"[{index:02d}/{len(cases)}] {args.mode} {case['id']}", flush=True)
+        try:
+            generated = rag.generate_cypher({"user_question": case["question"]})["generated_cypher"]
+            if args.mode == "full":
+                retrieval = rag.retrieve({"generated_cypher": generated})
+                executed_query = retrieval["generated_cypher"]
+                context = retrieval["context"]
+            else:
+                executed_query = ensure_limit(strip_code_fences(generated), rag.max_results)
+                validate_read_only(executed_query)
+                context = rag.database.query(executed_query)
+
+            context_text = normalize_for_scoring(
+                json.dumps(context, ensure_ascii=False, default=str)
+            )
+            expected_text = normalize_for_scoring(case["expected"])
+            tolower_count = len(re.findall(r"\btoLower\s*\(", executed_query, re.IGNORECASE))
+            rows.append(
+                {
+                    **case,
+                    "generated_cypher": generated,
+                    "executed_cypher": executed_query,
+                    "context": context,
+                    "hit": expected_text in context_text,
+                    "non_empty": bool(context),
+                    "tolower_compliant": tolower_count >= 2,
+                    "error": None,
+                }
+            )
+        except Exception as exc:
+            rows.append(
+                {
+                    **case,
+                    "generated_cypher": None,
+                    "executed_cypher": None,
+                    "context": [],
+                    "hit": False,
+                    "non_empty": False,
+                    "tolower_compliant": False,
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+            )
+
+    result = {
+        "mode": args.mode,
+        "revision": str(repo_root),
+        "source": source,
+        "provider": args.provider,
+        "model": model_name,
+        "case_count": len(rows),
+        "summary": summarize(rows),
+        "rows": rows,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
+    return result
+
+
+def main() -> None:
+    args = parse_args()
+    result = run_benchmark(args)
+    print(json.dumps(result["summary"], indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/seed_text2cypher_normalization.py
+++ b/benchmarks/seed_text2cypher_normalization.py
@@ -1,0 +1,113 @@
+"""Seed the normalization benchmark graph through the repository ingestion prompt."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+def clean_generated_cypher(raw: str) -> str:
+    """Turn the ingestion prompt's pipe-separated output into one Cypher query."""
+    value = raw.strip()
+    if value.startswith("```"):
+        lines = value.splitlines()
+        lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines.pop()
+        value = "\n".join(lines).strip()
+
+    parts = [part.strip() for part in value.split("|") if part.strip()]
+    if not parts or any(not part.upper().startswith("MERGE") for part in parts):
+        raise ValueError("Ingestion model returned non-MERGE Cypher output")
+    return "\n".join(parts)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--fixture", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--env-file", type=Path, default=Path(".env"))
+    parser.add_argument("--neo4j-uri", default="bolt://localhost:17687")
+    parser.add_argument("--provider", choices=("openai", "clarin"), default="openai")
+    return parser.parse_args()
+
+
+def seed_graph(args: argparse.Namespace) -> dict[str, object]:
+    """Generate graph writes with the selected revision's ingestion configuration."""
+    repo_root = args.repo_root.resolve()
+    load_dotenv(args.env_file.resolve(), override=False)
+    os.environ["NEO4J_URI"] = args.neo4j_uri
+    sys.path.insert(0, str(repo_root))
+    os.chdir(repo_root)
+
+    from langchain_core.output_parsers import StrOutputParser
+    from langchain_core.prompts import PromptTemplate
+    from langchain_openai import ChatOpenAI
+    from langchain_openai.chat_models.base import BaseChatOpenAI
+    from neo4j import GraphDatabase
+    from pydantic import SecretStr
+
+    from src.config.config import get_config
+
+    config = get_config()
+    if args.provider == "clarin":
+        model_name = config.llm.clarin.name
+        model = ChatOpenAI(
+            model_name=model_name,
+            base_url=config.llm.clarin.base_url,
+            api_key=os.environ["CLARIN_API_KEY"],
+            temperature=0,
+        )
+    else:
+        model_name = config.llm.accurate_model.name
+        model = BaseChatOpenAI(
+            model=model_name,
+            api_key=SecretStr(os.environ["OPENAI_API_KEY"]),
+            temperature=config.llm.accurate_model.temperature,
+        )
+    prompt = PromptTemplate(
+        input_variables=["context", "schema_context"],
+        template=config.prompts.cypher_insert,
+    )
+    fixture = args.fixture.resolve().read_text(encoding="utf-8")
+    raw = (prompt | model | StrOutputParser()).invoke(
+        {"context": fixture, "schema_context": "(empty — first pass)"}
+    )
+    cypher = clean_generated_cypher(raw)
+
+    username = os.environ["NEO4J_USER"]
+    password = os.environ["NEO4J_PASSWORD"]
+    with GraphDatabase.driver(args.neo4j_uri, auth=(username, password)) as driver:
+        driver.execute_query(cypher, database_="neo4j")
+        records, _, _ = driver.execute_query(
+            "MATCH (n) RETURN labels(n) AS labels, n.title AS title, "
+            "n.context AS context ORDER BY n.title",
+            database_="neo4j",
+        )
+
+    result = {
+        "revision": str(repo_root),
+        "provider": args.provider,
+        "model": model_name,
+        "temperature": 0,
+        "generated_cypher": cypher,
+        "nodes": [record.data() for record in records],
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
+    return result
+
+
+def main() -> None:
+    result = seed_graph(parse_args())
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/text2cypher_normalization_entities.json
+++ b/benchmarks/text2cypher_normalization_entities.json
@@ -1,0 +1,41 @@
+{
+  "source": "https://pwr.edu.pl/wydzialy",
+  "question_template": "Pokaż informacje o jednostce \"{entity}\".",
+  "entities": [
+    {
+      "id": "civil-engineering",
+      "original": "Wydział Budownictwa Lądowego i Wodnego",
+      "stored": "Wydzial Budownictwa Ladowego i Wodnego"
+    },
+    {
+      "id": "computer-science",
+      "original": "Wydział Informatyki i Telekomunikacji",
+      "stored": "Wydzial Informatyki i Telekomunikacji"
+    },
+    {
+      "id": "geoengineering",
+      "original": "Wydział Geoinżynierii, Górnictwa i Geologii",
+      "stored": "Wydzial Geoinzynierii, Gornictwa i Geologii"
+    },
+    {
+      "id": "environmental-engineering",
+      "original": "Wydział Inżynierii Środowiska",
+      "stored": "Wydzial Inzynierii Srodowiska"
+    },
+    {
+      "id": "management",
+      "original": "Wydział Zarządzania",
+      "stored": "Wydzial Zarzadzania"
+    },
+    {
+      "id": "mechanical-energy",
+      "original": "Wydział Mechaniczno-Energetyczny",
+      "stored": "Wydzial Mechaniczno-Energetyczny"
+    },
+    {
+      "id": "electronics-photonics",
+      "original": "Wydział Elektroniki, Fotoniki i Mikrosystemów",
+      "stored": "Wydzial Elektroniki, Fotoniki i Mikrosystemow"
+    }
+  ]
+}

--- a/docker/Dockerfile.mcp
+++ b/docker/Dockerfile.mcp
@@ -20,6 +20,7 @@ RUN groupadd -r mcpuser && useradd -r -g mcpuser mcpuser
 COPY --from=builder /app/.venv /app/.venv
 COPY ./src/mcp_server ./src/mcp_server
 COPY ./src/config ./src/config
+COPY ./src/text_normalization.py ./src/text_normalization.py
 COPY ./src/__init__.py ./src/__init__.py
 COPY ./graph_config.yaml ./graph_config.yaml
 

--- a/docker/Dockerfile.prefect
+++ b/docker/Dockerfile.prefect
@@ -25,6 +25,7 @@ RUN apt-get update \
 COPY --from=builder /app/.venv /app/.venv
 COPY ./src/data_pipeline ./src/data_pipeline
 COPY ./src/config ./src/config
+COPY ./src/text_normalization.py ./src/text_normalization.py
 COPY ./src/__init__.py ./src/__init__.py
 COPY ./graph_config.yaml ./graph_config.yaml
 

--- a/graph_config.yaml
+++ b/graph_config.yaml
@@ -140,11 +140,21 @@ prompts:
     Schema (includes sample property values):
     {schema}
 
-    Question: {user_question}
+    Original question (use this to understand intent): {user_question}
+    Normalized search form (use this for string values): {normalized_question}
 
     Rules:
     - Use MATCH, not MERGE or CREATE
-    - For string properties use case-insensitive fuzzy matching: toLower(n.title) CONTAINS toLower('...')
+    - Copy node labels, relationship types, and property keys exactly from the schema,
+      including their case; never invent schema identifiers
+    - Never alter or normalize labels, relationship types, or property keys
+    - Human-readable string comparison literals must come from the normalized search form and
+      use lowercase ASCII text without Polish diacritics
+    - Preserve the exact spelling and case of stable IDs; do not treat IDs as human-readable text
+    - For string properties use case-insensitive matching on both sides, for example:
+      toLower(n.title) CONTAINS toLower('wydzial informatyki')
+    - Prefer CONTAINS for human-readable entity names; use exact equality only for stable IDs or
+      non-string values
     - Always RETURN named properties, not full nodes (e.g. RETURN p.title, c.title)
     - Always add LIMIT 10
 

--- a/src/data_pipeline/flows/llm_cypher_generation.py
+++ b/src/data_pipeline/flows/llm_cypher_generation.py
@@ -10,6 +10,7 @@ from prefect import get_run_logger, task
 from pydantic import SecretStr
 
 from src.config.config import get_config
+from src.text_normalization import fold_diacritics, normalize_cypher_string_literals
 
 
 class PipeState(MessagesState):
@@ -95,6 +96,7 @@ def generate_cypher_queries(extracted_text: str, schema_context: str = "") -> st
     logger = get_run_logger()
     llm = LLMPipe()
     parts = llm.run(extracted_text, schema_context)
+    parts = [normalize_cypher_string_literals(part, normalizer=fold_diacritics) for part in parts]
 
     try:
         logger.info("LLM returned %d parts", len(parts))

--- a/src/mcp_server/tools/knowledge_graph/rag.py
+++ b/src/mcp_server/tools/knowledge_graph/rag.py
@@ -19,6 +19,7 @@ from ....config.config import get_config
 from ....config.messages import GRAPH_PIPELINE_TIMEOUT_MESSAGE
 from ....config.timeouts import get_graph_timeout_seconds, get_llm_timeout_seconds
 from ....text_normalization import (
+    ensure_case_insensitive_fuzzy_matching,
     fold_diacritics,
     normalize_cypher_string_literals,
     normalize_search_text,
@@ -409,6 +410,7 @@ class RAG:
                 cypher_query,
                 normalizer=fold_diacritics,
             )
+            cypher_query = ensure_case_insensitive_fuzzy_matching(cypher_query)
             validate_read_only(cypher_query)
             cypher_query = ensure_limit(cypher_query, self.max_results)
 

--- a/src/mcp_server/tools/knowledge_graph/rag.py
+++ b/src/mcp_server/tools/knowledge_graph/rag.py
@@ -18,6 +18,11 @@ from openai import APIConnectionError, APITimeoutError, InternalServerError, Rat
 from ....config.config import get_config
 from ....config.messages import GRAPH_PIPELINE_TIMEOUT_MESSAGE
 from ....config.timeouts import get_graph_timeout_seconds, get_llm_timeout_seconds
+from ....text_normalization import (
+    fold_diacritics,
+    normalize_cypher_string_literals,
+    normalize_search_text,
+)
 from .cypher_guardrails import (
     UnsafeCypherQueryError,
     ensure_limit,
@@ -275,7 +280,7 @@ class RAG:
         config = get_config()
 
         self.generate_cypher_template = PromptTemplate(
-            input_variables=["user_question", "schema"],
+            input_variables=["user_question", "normalized_question", "schema"],
             template=config.prompts.cypher_search,
         )
 
@@ -348,6 +353,15 @@ class RAG:
 
         return builder.compile()
 
+    @staticmethod
+    def _build_cypher_prompt_payload(user_question: str, schema: str) -> dict[str, str]:
+        """Provide both natural-language and canonical search forms to the LLM."""
+        return {
+            "user_question": user_question,
+            "normalized_question": normalize_search_text(user_question),
+            "schema": schema,
+        }
+
     def generate_cypher(self, state: State):
         """
         Generate CYPHER query from user question using database schema.
@@ -364,10 +378,7 @@ class RAG:
 
         chain = self.generate_cypher_template | self.cypher_llm | StrOutputParser()
         generated_cypher = chain.invoke(
-            {
-                "user_question": state["user_question"],
-                "schema": schema,
-            },
+            self._build_cypher_prompt_payload(state["user_question"], schema),
             config=self._get_invoke_config(
                 trace_id=state.get("trace_id"),
                 tags=["knowledge_graph", "generated_cypher"],
@@ -394,12 +405,16 @@ class RAG:
 
         try:
             cypher_query = strip_code_fences(cypher_query)
+            cypher_query = normalize_cypher_string_literals(
+                cypher_query,
+                normalizer=fold_diacritics,
+            )
             validate_read_only(cypher_query)
             cypher_query = ensure_limit(cypher_query, self.max_results)
 
             response = self.database.query(cypher_query)
 
-            return {"context": response}
+            return {"context": response, "generated_cypher": cypher_query}
 
         except UnsafeCypherQueryError as e:
             error_msg = f"Blocked unsafe Cypher: {e}"

--- a/src/text_normalization.py
+++ b/src/text_normalization.py
@@ -7,6 +7,24 @@ from collections.abc import Callable
 POLISH_DIACRITIC_TRANSLATION = str.maketrans({"ł": "l", "Ł": "L"})
 CYPHER_STRING_LITERAL_RE = re.compile(r"'(?:\\.|[^'\\])*'|\"(?:\\.|[^\"\\])*\"")
 LIST_PREFIX_KEYWORDS = {"IN", "RETURN", "WITH", "UNWIND", "AS", "THEN", "ELSE"}
+_CYPHER_IDENTIFIER = r"(?:`[^`]+`|[A-Za-z_]\w*)"
+_CYPHER_PROPERTY = (
+    rf"{_CYPHER_IDENTIFIER}(?:\s*\.\s*{_CYPHER_IDENTIFIER}"
+    rf"|\s*\[\s*(?:{CYPHER_STRING_LITERAL_RE.pattern})\s*\])"
+)
+_LOWERED_PROPERTY = rf"(?:toLower\s*\(\s*{_CYPHER_PROPERTY}\s*\)|{_CYPHER_PROPERTY})"
+_LOWERED_LITERAL = (
+    rf"(?:toLower\s*\(\s*(?:{CYPHER_STRING_LITERAL_RE.pattern})\s*\)"
+    rf"|(?:{CYPHER_STRING_LITERAL_RE.pattern}))"
+)
+CASE_SENSITIVE_FUZZY_COMPARISON_RE = re.compile(
+    rf"(?P<property>{_LOWERED_PROPERTY})"
+    rf"(?P<before_operator>\s+)"
+    rf"(?P<operator>CONTAINS|STARTS\s+WITH|ENDS\s+WITH)"
+    rf"(?P<after_operator>\s+)"
+    rf"(?P<literal>{_LOWERED_LITERAL})",
+    re.IGNORECASE,
+)
 
 
 def fold_diacritics(value: str) -> str:
@@ -19,6 +37,32 @@ def fold_diacritics(value: str) -> str:
 def normalize_search_text(value: str) -> str:
     """Return the canonical case- and diacritic-insensitive search representation."""
     return fold_diacritics(value).casefold()
+
+
+def ensure_case_insensitive_fuzzy_matching(cypher: str) -> str:
+    """Make human-readable Cypher fuzzy comparisons case-insensitive.
+
+    Exact equality is deliberately left unchanged because the retrieval prompt reserves it for
+    stable IDs, whose spelling and case may be significant.
+    """
+
+    def lower(expression: str) -> str:
+        if re.match(r"toLower\s*\(", expression, re.IGNORECASE):
+            return expression
+        return f"toLower({expression})"
+
+    def replace_comparison(match: re.Match[str]) -> str:
+        return "".join(
+            (
+                lower(match.group("property")),
+                match.group("before_operator"),
+                match.group("operator"),
+                match.group("after_operator"),
+                lower(match.group("literal")),
+            )
+        )
+
+    return CASE_SENSITIVE_FUZZY_COMPARISON_RE.sub(replace_comparison, cypher)
 
 
 def normalize_cypher_string_literals(

--- a/src/text_normalization.py
+++ b/src/text_normalization.py
@@ -1,0 +1,58 @@
+"""Deterministic text normalization shared by ingestion and retrieval."""
+
+import re
+import unicodedata
+from collections.abc import Callable
+
+POLISH_DIACRITIC_TRANSLATION = str.maketrans({"ł": "l", "Ł": "L"})
+CYPHER_STRING_LITERAL_RE = re.compile(r"'(?:\\.|[^'\\])*'|\"(?:\\.|[^\"\\])*\"")
+LIST_PREFIX_KEYWORDS = {"IN", "RETURN", "WITH", "UNWIND", "AS", "THEN", "ELSE"}
+
+
+def fold_diacritics(value: str) -> str:
+    """Fold Polish and decomposable Unicode diacritics while preserving case."""
+    translated = value.translate(POLISH_DIACRITIC_TRANSLATION)
+    decomposed = unicodedata.normalize("NFKD", translated)
+    return "".join(character for character in decomposed if not unicodedata.combining(character))
+
+
+def normalize_search_text(value: str) -> str:
+    """Return the canonical case- and diacritic-insensitive search representation."""
+    return fold_diacritics(value).casefold()
+
+
+def normalize_cypher_string_literals(
+    cypher: str,
+    *,
+    normalizer: Callable[[str], str] = fold_diacritics,
+) -> str:
+    """Normalize quoted Cypher values while preserving dynamic property keys."""
+
+    def is_dynamic_property_key(match: re.Match[str]) -> bool:
+        left = match.start() - 1
+        while left >= 0 and cypher[left].isspace():
+            left -= 1
+
+        right = match.end()
+        while right < len(cypher) and cypher[right].isspace():
+            right += 1
+
+        if left < 0 or right >= len(cypher) or cypher[left] != "[" or cypher[right] != "]":
+            return False
+
+        prefix = cypher[:left].rstrip()
+        preceding_token = re.search(r"([A-Za-z_]\w*)$", prefix)
+        if preceding_token and preceding_token.group(1).upper() in LIST_PREFIX_KEYWORDS:
+            return False
+
+        return bool(prefix) and (prefix[-1].isalnum() or prefix[-1] in "_)]")
+
+    def replace_literal(match: re.Match[str]) -> str:
+        if is_dynamic_property_key(match):
+            return match.group(0)
+
+        literal = match.group(0)
+        quote = literal[0]
+        return f"{quote}{normalizer(literal[1:-1])}{quote}"
+
+    return CYPHER_STRING_LITERAL_RE.sub(replace_literal, cypher)

--- a/tests/data_pipeline/test_llm_cypher_generation.py
+++ b/tests/data_pipeline/test_llm_cypher_generation.py
@@ -1,0 +1,21 @@
+from unittest.mock import MagicMock
+
+from src.data_pipeline.flows import llm_cypher_generation as cypher_module
+
+
+def test_generated_write_literals_are_diacritic_folded(monkeypatch) -> None:
+    class FakePipe:
+        def run(self, context: str, schema_context: str = "") -> list[str]:
+            return [
+                "MERGE (n:Faculty {title: 'Wydział Łączności', "
+                "context: 'Znajduje się we Wrocławiu'})"
+            ]
+
+    monkeypatch.setattr(cypher_module, "LLMPipe", FakePipe)
+    monkeypatch.setattr(cypher_module, "get_run_logger", MagicMock)
+
+    result = cypher_module.generate_cypher_queries.fn("source text")
+
+    assert result == (
+        "MERGE (n:Faculty {title: 'Wydzial Lacznosci', context: 'Znajduje sie we Wroclawiu'})"
+    )

--- a/tests/test_rag_retrieval_normalization.py
+++ b/tests/test_rag_retrieval_normalization.py
@@ -1,0 +1,101 @@
+from unittest.mock import MagicMock
+
+from src.mcp_server.tools.knowledge_graph.rag import RAG
+
+
+def _retrieval_stub() -> RAG:
+    rag = object.__new__(RAG)
+    rag.max_results = 5
+    rag.enable_debug = False
+    rag.database = MagicMock()
+    return rag
+
+
+def test_cypher_prompt_payload_keeps_original_and_adds_normalized_question() -> None:
+    payload = RAG._build_cypher_prompt_payload(
+        "Gdzie jest Wydział Informatyki we Wrocławiu?",
+        "(:Department {title: STRING})",
+    )
+
+    assert payload == {
+        "user_question": "Gdzie jest Wydział Informatyki we Wrocławiu?",
+        "normalized_question": "gdzie jest wydzial informatyki we wroclawiu?",
+        "schema": "(:Department {title: STRING})",
+    }
+
+
+def test_retrieve_normalizes_only_string_values_before_database_query() -> None:
+    rag = _retrieval_stub()
+    rag.database.query.return_value = [{"title": "Wydzial Informatyki"}]
+    state = {
+        "generated_cypher": (
+            "MATCH (wydział:Wydział) "
+            "WHERE toLower(wydział.tytuł) CONTAINS toLower('WYDZIAŁ INFORMATYKI') "
+            "RETURN wydział.tytuł"
+        )
+    }
+
+    result = rag.retrieve(state)
+
+    executed_query = (
+        "MATCH (wydział:Wydział) "
+        "WHERE toLower(wydział.tytuł) CONTAINS toLower('WYDZIAL INFORMATYKI') "
+        "RETURN wydział.tytuł LIMIT 5"
+    )
+    rag.database.query.assert_called_once_with(executed_query)
+    assert result == {
+        "context": [{"title": "Wydzial Informatyki"}],
+        "generated_cypher": executed_query,
+    }
+
+
+def test_retrieve_preserves_dynamic_property_key_case() -> None:
+    rag = _retrieval_stub()
+    rag.database.query.return_value = [{"title": "Wroclaw"}]
+
+    result = rag.retrieve(
+        {
+            "generated_cypher": (
+                "MATCH (n:Faculty) "
+                "WHERE toLower(n['ExactTitle']) = toLower('WROCŁAW') "
+                "RETURN n['ExactTitle']"
+            )
+        }
+    )
+
+    executed_query = (
+        "MATCH (n:Faculty) "
+        "WHERE toLower(n['ExactTitle']) = toLower('WROCLAW') "
+        "RETURN n['ExactTitle'] LIMIT 5"
+    )
+    rag.database.query.assert_called_once_with(executed_query)
+    assert result["generated_cypher"] == executed_query
+
+
+def test_retrieve_preserves_case_for_stable_ids() -> None:
+    rag = _retrieval_stub()
+    rag.database.query.return_value = [{"id": "AbC-123"}]
+
+    result = rag.retrieve(
+        {"generated_cypher": ("MATCH (n:Faculty) WHERE n.id = 'AbC-123' RETURN n.id")}
+    )
+
+    executed_query = "MATCH (n:Faculty) WHERE n.id = 'AbC-123' RETURN n.id LIMIT 5"
+    rag.database.query.assert_called_once_with(executed_query)
+    assert result["generated_cypher"] == executed_query
+
+
+def test_retrieve_still_blocks_disallowed_call_after_normalization() -> None:
+    rag = _retrieval_stub()
+
+    result = rag.retrieve(
+        {
+            "generated_cypher": (
+                "CALL db.index.fulltext.queryNodes('Wydziały', 'WROCŁAW') YIELD node RETURN node"
+            )
+        }
+    )
+
+    rag.database.query.assert_not_called()
+    assert result["context"] == []
+    assert result["generated_cypher"].startswith("Blocked unsafe Cypher:")

--- a/tests/test_rag_retrieval_normalization.py
+++ b/tests/test_rag_retrieval_normalization.py
@@ -85,6 +85,26 @@ def test_retrieve_preserves_case_for_stable_ids() -> None:
     assert result["generated_cypher"] == executed_query
 
 
+def test_retrieve_enforces_case_insensitive_fuzzy_matching() -> None:
+    rag = _retrieval_stub()
+    rag.database.query.return_value = [{"title": "Wydzial Zarzadzania"}]
+
+    result = rag.retrieve(
+        {
+            "generated_cypher": (
+                "MATCH (n:Faculty) WHERE n.title CONTAINS 'WYDZIAŁ ZARZĄDZANIA' RETURN n.title"
+            )
+        }
+    )
+
+    executed_query = (
+        "MATCH (n:Faculty) WHERE toLower(n.title) CONTAINS "
+        "toLower('WYDZIAL ZARZADZANIA') RETURN n.title LIMIT 5"
+    )
+    rag.database.query.assert_called_once_with(executed_query)
+    assert result["generated_cypher"] == executed_query
+
+
 def test_retrieve_still_blocks_disallowed_call_after_normalization() -> None:
     rag = _retrieval_stub()
 

--- a/tests/test_text2cypher_benchmark.py
+++ b/tests/test_text2cypher_benchmark.py
@@ -1,0 +1,70 @@
+from benchmarks.run_text2cypher_normalization import load_cases, summarize
+from benchmarks.seed_text2cypher_normalization import clean_generated_cypher
+
+
+def test_load_cases_builds_all_four_variants(tmp_path) -> None:
+    path = tmp_path / "entities.json"
+    path.write_text(
+        """{
+          "source": "https://example.test",
+          "question_template": "Znajdź {entity}",
+          "entities": [{
+            "id": "faculty",
+            "original": "Wydział Zarządzania",
+            "stored": "Wydzial Zarzadzania"
+          }]
+        }""",
+        encoding="utf-8",
+    )
+
+    source, cases = load_cases(path)
+
+    assert source == "https://example.test"
+    assert [case["category"] for case in cases] == [
+        "canonical",
+        "diacritics",
+        "case",
+        "case_and_diacritics",
+    ]
+    assert cases[1]["question"] == "Znajdź Wydział Zarządzania"
+    assert cases[2]["question"] == "Znajdź wydzial zarzadzania"
+    assert cases[3]["search_value"] == "wydział zarządzania"
+
+
+def test_summarize_reports_rates_by_category_and_overall() -> None:
+    rows = [
+        {
+            "category": "canonical",
+            "hit": True,
+            "non_empty": True,
+            "tolower_compliant": True,
+        },
+        {
+            "category": "case",
+            "hit": False,
+            "non_empty": True,
+            "tolower_compliant": False,
+        },
+    ]
+
+    summary = summarize(rows)
+
+    assert summary["canonical"]["hit_rate"] == 1.0
+    assert summary["case"]["hit_rate"] == 0.0
+    assert summary["overall"] == {
+        "total": 2,
+        "hits": 1,
+        "hit_rate": 0.5,
+        "non_empty": 2,
+        "non_empty_rate": 1.0,
+        "tolower_compliant": 1,
+        "tolower_compliance_rate": 0.5,
+    }
+
+
+def test_clean_generated_cypher_joins_ingestion_parts() -> None:
+    raw = "```cypher\nMERGE (a:Faculty {title: 'A'})|MERGE (b:Faculty {title: 'B'})\n```"
+
+    assert clean_generated_cypher(raw) == (
+        "MERGE (a:Faculty {title: 'A'})\nMERGE (b:Faculty {title: 'B'})"
+    )

--- a/tests/test_text_normalization.py
+++ b/tests/test_text_normalization.py
@@ -1,6 +1,7 @@
 import pytest
 
 from src.text_normalization import (
+    ensure_case_insensitive_fuzzy_matching,
     fold_diacritics,
     normalize_cypher_string_literals,
     normalize_search_text,
@@ -89,3 +90,46 @@ def test_normalize_cypher_string_literals_preserves_escaping() -> None:
 def test_normalize_cypher_string_literals_preserves_unquoted_query() -> None:
     query = "MATCH (n:Wydział) RETURN n.tytuł LIMIT 10"
     assert normalize_cypher_string_literals(query, normalizer=normalize_search_text) == query
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        (
+            "MATCH (n) WHERE n.title CONTAINS 'Wydzial' RETURN n.title",
+            "MATCH (n) WHERE toLower(n.title) CONTAINS toLower('Wydzial') RETURN n.title",
+        ),
+        (
+            "MATCH (n) WHERE toLower(n.title) STARTS WITH 'Wydzial' RETURN n.title",
+            "MATCH (n) WHERE toLower(n.title) STARTS WITH toLower('Wydzial') RETURN n.title",
+        ),
+        (
+            "MATCH (n) WHERE n.title ENDS WITH toLower('Wodnego') RETURN n.title",
+            "MATCH (n) WHERE toLower(n.title) ENDS WITH toLower('Wodnego') RETURN n.title",
+        ),
+        (
+            "MATCH (n) WHERE n['ExactTitle'] CONTAINS 'Wydzial' RETURN n['ExactTitle']",
+            "MATCH (n) WHERE toLower(n['ExactTitle']) CONTAINS toLower('Wydzial') "
+            "RETURN n['ExactTitle']",
+        ),
+        (
+            'MATCH (n) WHERE n.`display title` CONTAINS "Wydzial" RETURN n',
+            'MATCH (n) WHERE toLower(n.`display title`) CONTAINS toLower("Wydzial") RETURN n',
+        ),
+    ],
+)
+def test_ensure_case_insensitive_fuzzy_matching_wraps_both_sides(
+    query: str,
+    expected: str,
+) -> None:
+    assert ensure_case_insensitive_fuzzy_matching(query) == expected
+
+
+def test_ensure_case_insensitive_fuzzy_matching_is_idempotent() -> None:
+    query = "MATCH (n) WHERE toLower(n.title) CONTAINS toLower('wydzial') RETURN n.title"
+    assert ensure_case_insensitive_fuzzy_matching(query) == query
+
+
+def test_ensure_case_insensitive_fuzzy_matching_preserves_stable_id_equality() -> None:
+    query = "MATCH (n) WHERE n.external_id = 'Faculty-ABC' RETURN n.title"
+    assert ensure_case_insensitive_fuzzy_matching(query) == query

--- a/tests/test_text_normalization.py
+++ b/tests/test_text_normalization.py
@@ -1,0 +1,91 @@
+import pytest
+
+from src.text_normalization import (
+    fold_diacritics,
+    normalize_cypher_string_literals,
+    normalize_search_text,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("Zażółć gęślą jaźń", "Zazolc gesla jazn"),
+        ("WROCŁAW", "WROCLAW"),
+        ("Łódź", "Lodz"),
+        ("ĆĘŁŃÓŚŹŻ", "CELNOSZZ"),
+        ("plain ASCII", "plain ASCII"),
+    ],
+)
+def test_fold_diacritics_preserves_case(raw: str, expected: str) -> None:
+    assert fold_diacritics(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("Wrocław", "wroclaw"),
+        ("WROCLAW", "wroclaw"),
+        ("wroclaw", "wroclaw"),
+        ("Wydział Informatyki", "wydzial informatyki"),
+        ("ŁÓDŹ", "lodz"),
+    ],
+)
+def test_normalize_search_text_is_case_and_diacritic_insensitive(
+    raw: str,
+    expected: str,
+) -> None:
+    assert normalize_search_text(raw) == expected
+
+
+def test_normalize_cypher_string_literals_does_not_change_identifiers() -> None:
+    query = (
+        "MATCH (wydział:Wydział) "
+        "WHERE wydział.tytuł CONTAINS 'Wydział Informatyki' "
+        'AND wydział.miasto = "WROCŁAW" '
+        "RETURN wydział.tytuł"
+    )
+
+    normalized = normalize_cypher_string_literals(query, normalizer=normalize_search_text)
+
+    assert normalized == (
+        "MATCH (wydział:Wydział) "
+        "WHERE wydział.tytuł CONTAINS 'wydzial informatyki' "
+        'AND wydział.miasto = "wroclaw" '
+        "RETURN wydział.tytuł"
+    )
+
+
+def test_normalize_cypher_string_literals_preserves_dynamic_property_keys() -> None:
+    query = (
+        "MATCH (n:Faculty) "
+        "WHERE toLower(n['ExactTitle']) CONTAINS toLower('WROCŁAW') "
+        "RETURN n['ExactTitle']"
+    )
+
+    assert normalize_cypher_string_literals(query, normalizer=normalize_search_text) == (
+        "MATCH (n:Faculty) "
+        "WHERE toLower(n['ExactTitle']) CONTAINS toLower('wroclaw') "
+        "RETURN n['ExactTitle']"
+    )
+
+
+def test_normalize_cypher_string_literals_normalizes_values_in_lists() -> None:
+    query = "MATCH (n) WHERE n.city IN ['WROCŁAW'] RETURN n.city"
+
+    assert normalize_cypher_string_literals(query, normalizer=normalize_search_text) == (
+        "MATCH (n) WHERE n.city IN ['wroclaw'] RETURN n.city"
+    )
+
+
+def test_normalize_cypher_string_literals_preserves_escaping() -> None:
+    query = r"MATCH (n) WHERE n.title = 'Wydział\' Informatyki' RETURN n.title"
+
+    assert normalize_cypher_string_literals(query, normalizer=normalize_search_text) == (
+        r"MATCH (n) WHERE n.title = 'wydzial\' informatyki' RETURN n.title"
+    )
+
+
+def test_normalize_cypher_string_literals_preserves_unquoted_query() -> None:
+    query = "MATCH (n:Wydział) RETURN n.tytuł LIMIT 10"
+    assert normalize_cypher_string_literals(query, normalizer=normalize_search_text) == query


### PR DESCRIPTION
## What changed

- pass both the original question and a lowercase, diacritic-folded search form to Text2Cypher
- fold Polish diacritics deterministically in generated Cypher string values before execution
- require exact schema identifiers while using toLower on both sides for human-readable text matching
- preserve dynamic property-key case and case-sensitive stable IDs
- apply the same deterministic diacritic folding to generated ingestion queries
- add focused regression tests and document the behavior

## Why

Neo4j string operators are case-sensitive, while graph values are written without Polish diacritics and user questions can still contain them. Prompt-only normalization could therefore return no rows for equivalent names such as Wrocław, WROCLAW, and wroclaw.

The post-processing intentionally leaves labels, relationship types, property keys, and stable IDs unchanged. Existing read-only guardrails remain in place, including the block on CALL; this fix does not introduce a full-text index or new infrastructure.

## Validation

- Targeted normalization and retrieval tests: 21 passed
- Full suite excluding the host-dependent OCR test: 97 passed, 1 deselected because Tesseract is unavailable on this machine
- Ruff check: passed
- Ruff format check: passed
- Git diff check: passed

Closes #46